### PR TITLE
SIDM-1459: Disable Spring Boot Actuator Endpoints in Demo environment

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,3 +1,7 @@
+locals {
+  secure_actuator_endpoints = "${var.env == "idam-prod" || var.env == "idam-demo" ? true : false}"
+}
+
 module "idam-web-public" {
   source                = "git@github.com:hmcts/moj-module-webapp?ref=master"
   product               = "${var.product}-${var.app}"
@@ -11,7 +15,8 @@ module "idam-web-public" {
   appinsights_instrumentation_key = "${var.appinsights_instrumentation_key}"
 
   app_settings = {
-    MANAGEMENT_SECURITY_ENABLED   = "${var.env == "idam-prod" ? "true" : "false"}"
+    MANAGEMENT_SECURITY_ENABLED   = "${local.secure_actuator_endpoints}"
+    ENDPOINTS_ENABLED             = "${local.secure_actuator_endpoints ? false : true}"
 
     // remove when SSL certificates are in place
     SSL_VERIFICATION_ENABLED      = "${var.env == "idam-prod" ? "true" : "false"}"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,15 @@ management:
   security:
     enabled: true
 
+# Enable the info and health endpoints
+# A given environment (such as prod) might disable all endpoints,
+# but info and health should still be enabled
+endpoints:
+  info:
+    enabled: true
+  health:
+    enabled: true
+
 ssl:
   verification:
     enabled: true


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-1459

### Change description ###
Disable the majority of actuator endpoints by requiring authentication. The exception to this is the `/health`.  It needs to be available as the CNP pipeline queries it during the build/deployment process.  Also `/info` endpoint is still enabled as it informs us that the correct version of the application is deployed to the environment.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```