### PR TITLE
Fixed the API URL for Preview webapps

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,5 +1,7 @@
 locals {
   secure_actuator_endpoints = "${var.env == "idam-prod" || var.env == "idam-demo" ? true : false}"
+
+  integration_env = "${var.env == "idam-preview" ? "idam-aat" : var.env}"
 }
 
 module "idam-web-public" {
@@ -21,6 +23,6 @@ module "idam-web-public" {
     // remove when SSL certificates are in place
     SSL_VERIFICATION_ENABLED      = "${var.env == "idam-prod" ? "true" : "false"}"
 
-    STRATEGIC_SERVICE_URL         = "http://idam-api-${var.env}.service.core-compute-${var.env}.internal"
+    STRATEGIC_SERVICE_URL         = "http://idam-api-${local.integration_env}.service.core-compute-${local.integration_env}.internal"
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Frontend webapps should use API in AAT when deployed as part of a pull request. This is to ensure that they are using prod-like code and minimise the risk of applying the proposed changes in master branch.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
