### PR TITLE
SIDM-1287: Account lockout message in Public does not match UI mockups

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -111,9 +111,7 @@ public.login.forgotten.password=Forgotten password?
 public.login.form.submit=Sign in
 
 public.login.error.locked.title=There is a problem with your account login details
-public.login.error.locked.instruction=Your account is locked due to too many unsuccessful attempts. 
-public.login.error.locked.instruction.unlock.account= to unlock your account. 
-public.login.error.locked.instruction.reset.password=reset your password
+public.login.error.locked.instruction=Your account is locked due to too many unsuccessful attempts.<br>You can <a href="{0}">reset your password</a> to unlock your account.
 public.login.error.suspended.title=There is a problem with your account login details
 public.login.error.suspended.instruction=Your account has been blocked. Contact us to get help signing in.
 public.login.error.other.title=Information is missing or invalid

--- a/src/main/webapp/WEB-INF/jsp/login.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login.jsp
@@ -45,9 +45,10 @@
                             </h2>
                             <div class="text">
                                 <p>
-                                    <spring:message  code="public.login.error.locked.instruction"/>
-                                    <a href="${forgotPasswordUrl}"><spring:message  code="public.login.error.locked.instruction.reset.password"/></a>
-                                    <spring:message  code="public.login.error.locked.instruction.unlock.account"/>
+                                    <spring:message
+                                        code="public.login.error.locked.instruction"
+                                        arguments="${forgotPasswordUrl}"
+                                        htmlEscape="false"/>
                                 </p>
                             </div>
                         </c:when>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-1287


### Change description ###
Updated the copy and html format of the account lockout message to match requirements.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
