### PR TITLE
SIDM-1275: Keep Privacy Policy and T&C pages in the same browser window

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/selfRegister.jsp
+++ b/src/main/webapp/WEB-INF/jsp/selfRegister.jsp
@@ -102,9 +102,9 @@
                         <form:input type="hidden" path="state" value="${state}"/>
                         <p class="body-text">
                             <spring:message code="public.register.read.our" />
-                            <a href="https://hmcts-access.service.gov.uk/privacy-policy" target="_blank"><spring:message code="public.register.privacy.policy" /></a>
+                            <a href="https://hmcts-access.service.gov.uk/privacy-policy"><spring:message code="public.register.privacy.policy" /></a>
                             <spring:message code="public.register.and" />
-                            <a href="https://hmcts-access.service.gov.uk/terms-and-conditions" target="_blank"><spring:message code="public.register.term.conditions" /></a>
+                            <a href="https://hmcts-access.service.gov.uk/terms-and-conditions"><spring:message code="public.register.term.conditions" /></a>
                         </p>
                         <input class="button" type="submit" value="<spring:message code="public.self.register.submit.button"/>">
                     </div>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-1275


### Change description ###
The behaviour of the links to Privacy Policy page and to T&C on the Sign Up page is not consistent - the links in the footer open up in the same browser window while the links close to the CTA button open up in a blank window. This PR fixes the inconsistency and as a side effect enables the "Back" button on the Privacy Policy page to work properly.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
