### PR TITLE
Enable SSL certificate verification and set HTTPS only

### DIFF
--- a/infrastructure/idam-saat.tfvars
+++ b/infrastructure/idam-saat.tfvars
@@ -1,2 +1,3 @@
 idam_api_url = "https://idam-api-idam-saat.service.core-compute-idam-saat.internal"
 ssl_verification_enabled = false
+https_only = "false"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -18,6 +18,7 @@ module "idam-web-public" {
   is_frontend           = "${var.env == "idam-preview" ? 0 : 1}"
   subscription          = "${var.subscription}"
   capacity              = "${var.capacity}"
+  https_only            = "${var.https_only}"
   additional_host_name  = "idam-web-public.${replace(var.env, "idam-", "")}.platform.hmcts.net"
   appinsights_instrumentation_key = "${var.appinsights_instrumentation_key}"
   common_tags = "${var.common_tags}"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -39,3 +39,8 @@ variable idam_api_url {
   description = "IdAM API URL"
   default = ""
 }
+
+variable "https_only" {
+  description = "Disable HTTP access to the web app (Azure triggers 301 to HTTPS)."
+  default = "true"
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
SIDM-1165


### Change description ###
Use `idam-api.<env>.platform.hmcts.net` to talk to API and enable SSL certificate verification for all environments but SAAT.
Also, disable HTTP access for all envs but SAAT.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
