### PR TITLE
Ignore Sonar's WEAK_HOSTNAME_VERIFIER rule

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/web/config/AppConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/config/AppConfiguration.java
@@ -48,7 +48,8 @@ public class AppConfiguration extends WebSecurityConfigurerAdapter {
             SSLContext sslContext = SSLContexts.custom()
                 .loadTrustMaterial(null, acceptingTrustStrategy)
                 .build();
-            HostnameVerifier allowAllHostnameVerifier = (hostName, session) -> true;
+            // ignore Sonar's weak hostname verifier as we are deliberately disabling SSL verification
+            HostnameVerifier allowAllHostnameVerifier = (hostName, session) -> true; // NOSONAR
 
             SSLConnectionSocketFactory allowAllSslSocketFactory = new SSLConnectionSocketFactory(
                 sslContext,


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Ignore Sonar's WEAK_HOSTNAME_VERIFIER rule as we are explicitly disabling SSL verification on non-prod environments to allow for .internal domain names.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
