### PR TITLE
[PREVIEW] SIDM-1701 add default continue button

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/useractivated.jsp
+++ b/src/main/webapp/WEB-INF/jsp/useractivated.jsp
@@ -13,13 +13,22 @@
             </h1>
         </header>
         <p class="lede"><spring:message code="public.user.activated.body" /></p>
-        <c:if test="${redirectUri != null}">
-            <p>
-                <a href="${fn:escapeXml(redirectUri)}" class="button">
-                    <spring:message code="public.common.button.continue.text" />
-                </a>
-            </p>
-        </c:if>
+        <c:choose>
+            <c:when test="${redirectUri != null}">
+                <p>
+                    <a href="${fn:escapeXml(redirectUri)}" class="button">
+                        <spring:message code="public.common.button.continue.text" />
+                    </a>
+                </p>
+            </c:when>
+            <c:otherwise>
+                <p>
+                    <a href="https://www.gov.uk/" class="button">
+                        <spring:message code="public.common.button.continue.text" />
+                    </a>
+                </p>
+            </c:otherwise>
+        </c:choose>
     </article>
     <script>
         sendEvent('User Activation', 'Success',  'User has been activated');


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-1701

### Change description ###

After activating a user show a default continue button that goes to the gov.uk homepage if a button would not otherwise be displayed. Admin users should always be directed to web-admin as before, and citizen users being activated for a service with an activation redirect url will continue to use that link as before. The functionality for self-registered users will also not change.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
