### PR TITLE
[PREVIEW] Remove redundant parameters in login form

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/login.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login.jsp
@@ -164,10 +164,6 @@
                 <input class="button" type="submit" name="save"
                        value="<spring:message code="public.login.form.submit" />">
 
-                <form:input path="redirect_uri" type="hidden" id="redirect_uri" name="redirect_uri"/>
-                <form:input path="client_id" type="hidden" id="client_id" name="client_id"/>
-                <form:input path="state" type="hidden" id="state" name="state"/>
-                <form:input path="response_type" type="hidden" id="response_type" name="response_type"/>
                 <form:input path="selfRegistrationEnabled" type="hidden" id="selfRegistrationEnabled" name="selfRegistrationEnabled" value="${selfRegistrationEnabled}"/>
             </div>
             <c:if test="${selfRegistrationEnabled}">


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Removed redundant request params in the login form as they are already present in the query string.
This is currently breaking login as the param values are passed twice, e.g. `client_id=cmc_citizen,cmc_citizen`.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
