### PR TITLE
SonarCloud integration for nightly builds

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -17,7 +17,8 @@ withNightlyPipeline(type, product, component) {
     enableMutationTest()
 
     after('mutationTest') {
-
-        sh "./gradlew --info sonarqube"
+        withSonarQubeEnv("SonarQube") {
+          sh "./gradlew --info sonarqube"
+        }
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Default envvars in Jenkins point to the old Sonar environment - sonar.reform.hmcts.net. In order to connect to the new SonarCloud, we need to use a pipeline function `withSonarQubeEnv`.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
