### PR TITLE
Lock module webapp to version

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -21,7 +21,7 @@ locals {
 }
 
 module "idam-web-public" {
-  source                = "git@github.com:hmcts/moj-module-webapp?ref=master"
+  source                = "git@github.com:hmcts/cnp-module-webapp?ref=0.1.0"
   product               = "${var.product}-${var.app}"
   location              = "${var.location}"
   env                   = "${var.env}"


### PR DESCRIPTION
We are about to make a breaking change to the module to remove the WAF from it
It's not expected that WAFs created in module webapp are used, it was technical debt which we are cleaning now, due to big cost + they are untagged and don't support it currently.

Idam was made aware ages ago of the shared infra approach, 
To not block idam we're locking you into the last version before the breaking change but please look to migrate over to shared infra, the subscription cannot handle every app having a WAF as there is a hard limit and shared infrastructure must be used
https://tools.hmcts.net/confluence/display/CNP/Shared+Infrastructure+Repository
https://github.com/hmcts/cnp-module-waf/blob/stripDownWf/README.md