### PR TITLE
Lock ARM template apiVersion

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,3 +1,7 @@
+provider "azurerm" {
+  version = "1.19.0"
+}
+
 locals {
   preview_vault_name = "idam-idam-preview"
   non_preview_vault_name = "${var.product}-${var.env}"


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Locked to an apiVersion used when doing ARM template deployments that's working. Helps against this error:
```
The api-version '2016-02-01' used to deploy the template does not support 'ResourceGroup' property. Please use api-version '2017-05-10' or later to deploy the template. Please see https://aka.ms/arm-template/#resources for usage details.'.
```



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
