### PR TITLE
Do not pass state param twice on login

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/login.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login.jsp
@@ -164,7 +164,6 @@
 
                 <input class="button" type="submit" name="save"
                        value="<spring:message code="public.login.form.submit" />">
-                <form:input path="state" type="hidden" id="state" name="state"/>
                 <form:input path="selfRegistrationEnabled" type="hidden" id="selfRegistrationEnabled" name="selfRegistrationEnabled" value="${selfRegistrationEnabled}"/>
             </div>
             <c:if test="${selfRegistrationEnabled}">


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-2381


### Change description ###
We are passing the state param twice which breaks the integration with some services that take the whole value of the query param instead of splitting by ",".


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
