### PR TITLE
Increase HTTP header size 

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -47,6 +47,7 @@ module "idam-web-public" {
   additional_host_name = "${local.env == "idam-preview" ? "null" : local.external_host_name}"
   appinsights_instrumentation_key = "${var.appinsights_instrumentation_key}"
   common_tags = "${local.tags}"
+  java_container_version = "9.0"
 
   asp_name = "${local.asp_name}"
   asp_rg = "${local.asp_rg}"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,6 +12,7 @@ server:
   tomcat:
     remote-ip-header: x-forwarded-for
     protocol-header: x-forwarded-proto
+  max-http-header-size: 24KB
 
 management:
   # Enable the info and health endpoints


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
* Increased max HTTP header size. Default in Tomcat is 8KB. This does not seem to be enough for the `/login/uplift` requests which contain a JWT as a URL param and _might_ contain another JWT as a session cookie (`iPlanetDirectoryPro`)
* Changed a setting in the webapp module that is not use at all `java_container_version`.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
