### PR TITLE
[PREVIEW] SIDM 2727 Reverse proxy idam-api /o/ path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,14 @@ allprojects  {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-security'
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-zuul', version: '2.1.1.RELEASE'
+    compile (group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-zuul', version: '2.1.1.RELEASE') {
+      exclude(module: 'rxnetty-contexts')
+      exclude(module: 'rxnetty-servo')
+      exclude(module: 'rxnetty')
+    }
+    compile group: 'io.reactivex', name: 'rxnetty', version: '0.4.12'
+    compile group: 'io.reactivex', name: 'rxnetty-contexts', version: '0.4.12'
+    compile group: 'io.reactivex', name: 'rxnetty-servo', version: '0.4.12'
     compile group: 'org.springframework.security', name: 'spring-security-taglibs'
     compile group: 'org.projectlombok', name: 'lombok'
     compile group: 'javax.servlet', name: 'jstl'

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,10 @@ import java.util.stream.Collectors
 plugins {
   id 'java'
   id 'jacoco'
-  id 'io.spring.dependency-management' version '1.0.7.RELEASE' apply false
+  id 'io.spring.dependency-management' version '1.0.8.RELEASE' apply false
   id 'org.owasp.dependencycheck' version '3.1.2'
   id 'org.sonarqube' version '2.6.2'
-  id 'org.springframework.boot' version '2.1.4.RELEASE' apply false
+  id 'org.springframework.boot' version '2.1.6.RELEASE' apply false
   id 'com.gorylenko.gradle-git-properties' version '1.4.21'
   id "info.solidsoft.pitest" version "1.3.0"
   id 'pmd'
@@ -31,10 +31,11 @@ allprojects  {
   sourceCompatibility = 1.8
   targetCompatibility = 1.8
 
-  def idamBomVersion = '1.5.14'
+  def idamBomVersion = '1.5.16'
 
   ext['tomcat.version'] = '9.0.19'
   ext['jackson.version'] = '2.9.9'
+  ext['spring.boot.version'] = '2.1.6.RELEASE'
 
   dependencyManagement {
     imports {
@@ -67,6 +68,7 @@ allprojects  {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-security'
+    compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-zuul', version: '2.1.1.RELEASE'
     compile group: 'org.springframework.security', name: 'spring-security-taglibs'
     compile group: 'org.projectlombok', name: 'lombok'
     compile group: 'javax.servlet', name: 'jstl'

--- a/build.gradle
+++ b/build.gradle
@@ -31,11 +31,10 @@ allprojects  {
   sourceCompatibility = 1.8
   targetCompatibility = 1.8
 
-  def idamBomVersion = '1.5.16'
+  def idamBomVersion = '1.5.17'
 
   ext['tomcat.version'] = '9.0.19'
   ext['jackson.version'] = '2.9.9'
-  ext['spring.boot.version'] = '2.1.6.RELEASE'
 
   dependencyManagement {
     imports {
@@ -68,7 +67,7 @@ allprojects  {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-security'
-    compile (group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-zuul', version: '2.1.1.RELEASE') {
+    compile (group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-zuul') {
       exclude(module: 'rxnetty-contexts')
       exclude(module: 'rxnetty-servo')
       exclude(module: 'rxnetty')

--- a/build.gradle
+++ b/build.gradle
@@ -73,9 +73,6 @@ allprojects  {
       exclude(module: 'rxnetty-servo')
       exclude(module: 'rxnetty')
     }
-    compile group: 'io.reactivex', name: 'rxnetty', version: '0.5.3'
-    compile group: 'io.reactivex', name: 'rxnetty-contexts', version: '0.5.3'
-    compile group: 'io.reactivex', name: 'rxnetty-servo', version: '0.5.3'
     compile group: 'org.springframework.security', name: 'spring-security-taglibs'
     compile group: 'org.projectlombok', name: 'lombok'
     compile group: 'javax.servlet', name: 'jstl'

--- a/build.gradle
+++ b/build.gradle
@@ -73,9 +73,9 @@ allprojects  {
       exclude(module: 'rxnetty-servo')
       exclude(module: 'rxnetty')
     }
-    compile group: 'io.reactivex', name: 'rxnetty', version: '0.4.12'
-    compile group: 'io.reactivex', name: 'rxnetty-contexts', version: '0.4.12'
-    compile group: 'io.reactivex', name: 'rxnetty-servo', version: '0.4.12'
+    compile group: 'io.reactivex', name: 'rxnetty', version: '0.5.3'
+    compile group: 'io.reactivex', name: 'rxnetty-contexts', version: '0.5.3'
+    compile group: 'io.reactivex', name: 'rxnetty-servo', version: '0.5.3'
     compile group: 'org.springframework.security', name: 'spring-security-taglibs'
     compile group: 'org.projectlombok', name: 'lombok'
     compile group: 'javax.servlet', name: 'jstl'

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -47,7 +47,6 @@ module "idam-web-public" {
   additional_host_name = "${local.env == "idam-preview" ? "null" : local.external_host_name}"
   appinsights_instrumentation_key = "${var.appinsights_instrumentation_key}"
   common_tags = "${local.tags}"
-  java_container_version = "9.0"
 
   asp_name = "${local.asp_name}"
   asp_rg = "${local.asp_rg}"

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/Application.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/Application.java
@@ -5,12 +5,14 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
 import org.springframework.context.annotation.ComponentScan;
 
 import uk.gov.hmcts.reform.idam.web.config.properties.ConfigurationProperties;
 
 @SpringBootApplication
 @ComponentScan("uk.gov.hmcts.reform.idam")
+@EnableZuulProxy
 @EnableConfigurationProperties(ConfigurationProperties.class)
 public class Application extends SpringBootServletInitializer {
 

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/config/AppConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/config/AppConfiguration.java
@@ -71,9 +71,11 @@ public class AppConfiguration extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
-            .csrf().csrfTokenRepository(new CookieCsrfTokenRepository()).and()
+            .csrf().ignoringAntMatchers("/o/**")
+            .csrfTokenRepository(new CookieCsrfTokenRepository()).and()
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
             .authorizeRequests()
+            .antMatchers("/o/**").permitAll()
             .antMatchers("/resources/**").permitAll()
             .antMatchers("/assets/**").permitAll()
             .antMatchers("/users/register").permitAll()

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,6 +20,10 @@ zuul:
       sensitiveHeaders: Set-Cookie
       url: ${strategic.service.url}/o
 
+ribbon:
+  ConnectTimeout: 10000
+  ReadTimeout: 10000
+
 management:
   # Enable the info and health endpoints
   # A given environment (such as prod) might disable all endpoints,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,13 @@ server:
     remote-ip-header: x-forwarded-for
     protocol-header: x-forwarded-proto
 
+zuul:
+  routes:
+    open-id-connect:
+      path: /o/**
+      sensitiveHeaders: Set-Cookie
+      url: ${strategic.service.url}/o
+
 management:
   # Enable the info and health endpoints
   # A given environment (such as prod) might disable all endpoints,


### PR DESCRIPTION
Allow for public facing web-public to proxy requests to web-public/o to idam-api/o so that we dont have to expose idam-api and web-public will have the same path as idam-api for OpenID Connect requests.

This is important as the Cookie will be available only for that location.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
