### PR TITLE
Suppress latest jackson issues

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -148,6 +148,15 @@
         <cve>CVE-2019-14379</cve>
     </suppress>
 
+    <!--
+    This vulnerability can only be explored if default typing is enabled in ObjectMapper.
+    -->
+    <suppress>
+        <notes>only relevant if objectMapper.enableDefaultTyping</notes>
+        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind.*$</gav>
+        <cve>CVE-2019-14439</cve>
+    </suppress>
+
     <suppress>
         <notes>suppress false positives - only relevant to tomcat &lt;= 8.4</notes>
         <gav regex="true">^org\.apache\.tomcat:tomcat-annotations-api:.*$</gav>


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
It's a false positive as we don't enable default typing in ObjectMapper.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
