### PR TITLE
[PREVIEW] SIDM-3007 SIDM-3089 add conditional case for asp_name when running PRs and update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG APP_INSIGHTS_AGENT_VERSION=2.4.0
 
 FROM hmctspublic.azurecr.io/base/java:openjdk-8-distroless-1.1
 
-LABEL maintainer=SIDAM \
+LABEL maintainer=IDAM \
       owner="HM Courts & Tribunals Service"
 
 # Docker Base Image Defaults
@@ -13,7 +13,8 @@ LABEL maintainer=SIDAM \
 ENV SERVER_PORT=8080
 
 ADD --chown=hmcts:hmcts build/libs/idam-web-public.war \
-                lib/AI-Agent.xml lib/applicationinsights-agent-2.4.0.jar /opt/app/
+                        lib/AI-Agent.xml \
+                        lib/applicationinsights-agent-2.4.0.jar /opt/app/
 
 CMD ["idam-web-public.war"]
 

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -193,4 +193,17 @@
         <cve>CVE-2014-0119</cve>
         <cve>CVE-2016-5388</cve>
     </suppress>
+
+    <!--
+    This should not apply to the project as this package is only used in testing.
+    -->
+    <suppress>
+        <notes> 
+        https://www.cvedetails.com/cve/CVE-2019-15052/
+        The HTTP client in the Build tool in Gradle before 5.6 sends authentication credentials originally destined for the configured host. If that host returns a 30x redirect, Gradle also sends those credentials to all subsequent hosts that the request redirects to. This is similar to CVE-2018-1000007.	
+        This should not apply to the project as this package is only used in testing.
+        </notes>
+        <gav regex="true">^info\.solidsoft\.gradle\.pitest:gradle-pitest-plugin:1\.3\.0$</gav>
+        <cve>CVE-2019-15052</cve>
+    </suppress>
 </suppressions>

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -16,7 +16,7 @@ locals {
   idam_api_testing_support_url = "${var.idam_api_testing_support_url_override != "" ? var.idam_api_testing_support_url_override : local.idam_api_url}"
 
   default_asp_name = "${var.product}-${var.env}"
-  asp_name = "${coalesce(var.asp_name_override, local.default_asp_name)}"
+  asp_name = "${substr(var.product, 0, 3) == "pr-" ? local.default_asp_name : coalesce(var.asp_name_override, local.default_asp_name)}"
 
   default_asp_rg = "${var.product}-${var.env}"
   asp_rg = "${coalesce(var.asp_rg_override, local.default_asp_rg)}"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-3007
https://tools.hmcts.net/jira/browse/SIDM-3089
https://tools.hmcts.net/jira/browse/SIDM-3090

### Change description ###

By using the asp_name_override for idam-api, idam-web-public and idam-web-admin for PRs, pipelines cannot run in parallel as they clash with each other.

Do not use asp_name_override for PRs.

This will cause all first pipelines to fail. The reason it fails the first time is that:

TF makes a request to build the ASP (and the RG)
Azure returns
TF starts deployment in the ASP however, the RG is not ready at this stage so it fails it needs some time..
This change checks the var.product value to assert whether the pipeline running the execution is a PR and does not use the override value in this case.

CVE-2019-15052 has been release last night and failing the security analysis in PR pipelines for pitest@1.3.0. 1.4.0 is the latest release and is also vulnerable. This is a testing package and so has been suppressed.

Update Dockerfile as base image is no longer available.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
