### PR TITLE
Suppress CVE-2019-14540 CVE-2019-16335

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -206,4 +206,16 @@
         <gav regex="true">^info\.solidsoft\.gradle\.pitest:gradle-pitest-plugin:1\.3\.0$</gav>
         <cve>CVE-2019-15052</cve>
     </suppress>
+    
+    <!--
+    This vulnerability can only be exploited if polymorphic typing is enabled on the default
+    object mapper, hence not relevant to us.
+    -->
+    <suppress>
+        <notes>suppress false positives - This vulnerability can only be exploited if polymorphic typing
+            is enabled on the default object mapper, hence not relevant to us.</notes>
+        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind.*$</gav>
+        <cve>CVE-2019-14540</cve>
+        <cve>CVE-2019-16335</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-3196

### Change description ###

https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.9.9.3 is still
vulnerable

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
