### PR TITLE
[PREVIEW] Fix nimbus-jose-jwt CVE-2019-17195

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,7 @@ allprojects  {
   sourceCompatibility = 1.8
   targetCompatibility = 1.8
 
-  def idamBomVersion = '1.6.4'
-
+  def idamBomVersion = '1.6.6'
   ext['tomcat.version'] = '9.0.22'
   ext['jackson.version'] = '2.9.9'
   
@@ -80,8 +79,8 @@ allprojects  {
     
     implementation group: 'javax.servlet', name: 'jstl'
     implementation group: 'javax.json', name: 'javax.json-api'
+    // TODO remove this hardcoded version when all of jackson > 2.9.9
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.9.3'
-    implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt'
     implementation group: 'org.apache.httpcomponents', name: 'httpclient'
     implementation group: 'org.apache.httpcomponents', name: 'httpcore'
     implementation group: 'org.apache.commons', name: 'commons-text'


### PR DESCRIPTION
### Change description ###

Update bom which contains updated version for package

`10:49:42  nimbus-jose-jwt-4.41.2.jar (pkg:maven/com.nimbusds/nimbus-jose-jwt@4.41.2, cpe:2.3:a:connect2id:nimbus_jose\+jwt:4.41.2:*:*:*:*:*:*:*) : CVE-2019-17195
`

Removes nimbus from deps as it is not used. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
