### PR TITLE
fix(aadidentityname): unset value in default values

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -50,7 +50,7 @@ withPipeline(type, product, component) {
     before('smoketest-aks:idam-preview') {
         env.PREVIEW_ENVIRONMENT_NAME = 'preview'   
         env.NONPROD_ENVIRONMENT_NAME = 'preview'
-        env.IDAMAPI = "https://idam-api-pr-472.service.core-compute-preview.internal"
+        env.IDAMAPI = "https://idam-api-pr-474.service.core-compute-preview.internal"
         println """Using PREVIEW_ENVIRONMENT_NAME: ${env.PREVIEW_ENVIRONMENT_NAME}
                    Using NONPROD_ENVIRONMENT_NAME: ${env.NONPROD_ENVIRONMENT_NAME}
                    Using IDAMAPI: ${env.IDAMAPI}""".stripIndent()
@@ -59,7 +59,7 @@ withPipeline(type, product, component) {
     before('functionalTest-aks:idam-preview') {
         env.PREVIEW_ENVIRONMENT_NAME = 'preview'
         env.NONPROD_ENVIRONMENT_NAME = 'preview'
-        env.IDAMAPI = "https://idam-api-pr-472.service.core-compute-preview.internal"
+        env.IDAMAPI = "https://idam-api-pr-474.service.core-compute-preview.internal"
         println """Using PREVIEW_ENVIRONMENT_NAME: ${env.PREVIEW_ENVIRONMENT_NAME}
                    Using NONPROD_ENVIRONMENT_NAME: ${env.NONPROD_ENVIRONMENT_NAME}
                    Using IDAMAPI: ${env.IDAMAPI}""".stripIndent()

--- a/charts/idam-web-public/Chart.yaml
+++ b/charts/idam-web-public/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for HMCTS Reform IDAM Web Public
 name: idam-web-public
-version: 0.2.0
+version: 0.2.1
 keywords:
 - java
 - web

--- a/charts/idam-web-public/values.preview.template.yaml
+++ b/charts/idam-web-public/values.preview.template.yaml
@@ -5,9 +5,8 @@ java:
   ingressHost: ${SERVICE_FQDN}
   ingressIP: ${INGRESS_IP}
   consulIP: ${CONSUL_LB_IP}
-  aadIdentityName: null
   environment:
-    STRATEGIC_SERVICE_URL: https://idam-api-pr-472.service.core-compute-preview.internal
+    STRATEGIC_SERVICE_URL: https://idam-api-pr-474.service.core-compute-preview.internal
     SSL_VERIFICATION_ENABLED: false
     ZUUL_SSLHOSTNAMEVALIDATIONENABLED: false
 

--- a/charts/idam-web-public/values.yaml
+++ b/charts/idam-web-public/values.yaml
@@ -6,7 +6,6 @@ java:
   ingressHost: "{{ .Chart.Name }}.service.core-compute-{{ .Values.global.environment }}.internal"
   replicas: 3
   applicationPort: 8080
-  aadIdentityName: idam
   keyVaults:
     "idam-idam":
       resourceGroup: idam-idam


### PR DESCRIPTION
### Change description ###

flux does not treat key: null the same way as helm and this causes the wrong templating to render in flux helmReleases

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
