### PR TITLE
feat(SIDM-3294-sess-fix): fix session bug

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/web/AppController.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/AppController.java
@@ -457,6 +457,7 @@ public class AppController {
 
     /**
      * @should submit otp authentication using authId cookie and otp code then call authorise and redirect the user
+     * @should submit otp authentication using authId cookie only to avoid session bugs
      * @should return verification view for INCORRECT_OTP 401 response
      * @should return login view for non INCORRECT_OTP 401 response
      * @should return login view for 403 response
@@ -489,7 +490,9 @@ public class AppController {
 
         final String ipAddress = ObjectUtils.defaultIfNull(httpRequest.getHeader(X_FORWARDED_FOR), httpRequest.getRemoteAddr());
 
+        final String otpSessCookieName = configurationProperties.getStrategic().getOtp().getOtpSessionIdCookie();
         final List<String> cookies = Arrays.stream(ofNullable(httpRequest.getCookies()).orElse(new Cookie[] {}))
+            .filter(c -> otpSessCookieName.equals(c.getName()))
             .map(c -> String.format("%s=%s", c.getName(), c.getValue())) // map to: "Idam.AuthId=xyz"
             .collect(Collectors.toList());
 

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/AppController.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/AppController.java
@@ -457,7 +457,7 @@ public class AppController {
 
     /**
      * @should submit otp authentication using authId cookie and otp code then call authorise and redirect the user
-     * @should submit otp authentication using authId cookie only to avoid session bugs
+     * @should submit otp authentication filtering out Idam.Session cookie to avoid session bugs
      * @should return verification view for INCORRECT_OTP 401 response
      * @should return login view for non INCORRECT_OTP 401 response
      * @should return login view for 403 response
@@ -490,9 +490,9 @@ public class AppController {
 
         final String ipAddress = ObjectUtils.defaultIfNull(httpRequest.getHeader(X_FORWARDED_FOR), httpRequest.getRemoteAddr());
 
-        final String otpSessCookieName = configurationProperties.getStrategic().getOtp().getOtpSessionIdCookie();
+        final String idamSessionCookie = configurationProperties.getStrategic().getSession().getIdamSessionCookie();
         final List<String> cookies = Arrays.stream(ofNullable(httpRequest.getCookies()).orElse(new Cookie[] {}))
-            .filter(c -> otpSessCookieName.equals(c.getName()))
+            .filter(c -> !idamSessionCookie.equals(c.getName()))
             .map(c -> String.format("%s=%s", c.getName(), c.getValue())) // map to: "Idam.AuthId=xyz"
             .collect(Collectors.toList());
 

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/config/properties/StrategicConfigurationProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/config/properties/StrategicConfigurationProperties.java
@@ -11,7 +11,7 @@ public class StrategicConfigurationProperties {
     private ServiceConfigurationProperties service;
     private EndpointConfigurationProperties endpoint;
     private Policies policies;
-    private Otp otp;
+    private Session session;
 
     @Data
     public static class ServiceConfigurationProperties {
@@ -48,7 +48,7 @@ public class StrategicConfigurationProperties {
     }
 
     @Data
-    public static class Otp {
-        private String otpSessionIdCookie;
+    public static class Session {
+        private String idamSessionCookie;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/strategic/PolicyService.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/strategic/PolicyService.java
@@ -46,7 +46,6 @@ public class PolicyService {
 
     public static final String ADVICE_KEY_MFA_REQUIRED = "mfaRequired";
     public static final String ADVICE_KEY_MFA_REQUIRED_STRING_VALUE = "true";
-    public static final String OPENAM_SSO_COOKIE_NAME = "Idam.Session";
 
     // Matches and captures ipv6 with port: 1fff:0:a88:85a3::ac1f
     // [1fff:0:a88:85a3::ac1f]:8001
@@ -73,8 +72,9 @@ public class PolicyService {
     public EvaluatePoliciesAction evaluatePoliciesForUser(final String uri, final List<String> cookies, final String ipAddress) {
         final String applicationName = configurationProperties.getStrategic().getPolicies().getApplicationName();
 
+        final String idamSessionCookie = configurationProperties.getStrategic().getSession().getIdamSessionCookie();
         String sessionCookie = cookies.stream().
-            filter(cookie -> cookie.contains(OPENAM_SSO_COOKIE_NAME)).findFirst()
+            filter(cookie -> cookie.contains(idamSessionCookie)).findFirst()
             .orElseThrow(() -> new HttpClientErrorException(HttpStatus.UNAUTHORIZED, "No valid authentication token found."));
 
         final String userSsoToken = StringUtils.substringAfter(sessionCookie, "=");

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -79,8 +79,8 @@ strategic:
     evaluatePolicies: api/v1/policies/evaluate
   policies:
     applicationName: HmctsPolicySet
-  otp:
-    otpSessionIdCookie: Idam.AuthId
+  session:
+    idamSessionCookie: Idam.Session
 
 validation:
   password:

--- a/src/test/java/uk/gov/hmcts/reform/idam/web/strategic/PolicyServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/web/strategic/PolicyServiceTest.java
@@ -58,6 +58,8 @@ public class PolicyServiceTest {
             .willReturn("idamApi");
         given(configurationProperties.getStrategic().getEndpoint().getEvaluatePolicies())
             .willReturn("evaluatePolicies");
+        given(configurationProperties.getStrategic().getSession().getIdamSessionCookie())
+            .willReturn("Idam.Session");
     }
 
     EvaluatePoliciesResponse mockResponse(final ActionMap actionMap) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-3294


### Change description ###
Shrav found a bug where AM ignores OTP code and uses any existing Idam.Session cookie and authenticates the user using that Idam.Session

To avoid that, we are filtering cookies and sending only the Idam.AuthId session to identify the OTP session forcing AM to validate the OTP using the Idam.AuthId


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
