### PR TITLE
feat(SIDM-3248): field validation: empty, numbers, length, incorrect

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/web/AppController.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/AppController.java
@@ -507,7 +507,6 @@ public class AppController {
         final String ipAddress = ObjectUtils.defaultIfNull(httpRequest.getHeader(X_FORWARDED_FOR), httpRequest.getRemoteAddr());
 
         final List<String> cookies = Arrays.stream(ofNullable(httpRequest.getCookies()).orElse(new Cookie[] {}))
-            .filter(c -> !"Idam.Session".equals(c.getName()))
             .map(c -> String.format("%s=%s", c.getName(), c.getValue())) // map to: "Idam.AuthId=xyz"
             .collect(Collectors.toList());
 

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/AppController.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/AppController.java
@@ -466,6 +466,9 @@ public class AppController {
      * @should return login view for non INCORRECT_OTP 401 response
      * @should return login view for 403 response
      * @should return login view when authorize fails
+     * @should validate code field is not empty
+     * @should validate code field is digits
+     * @should validate code field is 8 digits
      */
     @PostMapping("/verification")
     public ModelAndView verification(@ModelAttribute("authorizeCommand") @Validated VerificationRequest request,

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/AppController.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/AppController.java
@@ -47,8 +47,10 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -483,13 +485,17 @@ public class AppController {
 
         final boolean validationErrors = bindingResult.hasErrors();
         if (validationErrors) {
-            final List<FieldError> codeErrors = bindingResult.getFieldErrors("code");
-            if (codeErrors.contains(NotEmpty.class.getSimpleName())) {
+            final List<FieldError> codeErrors = ofNullable(bindingResult.getFieldErrors("code"))
+                .orElse(Collections.emptyList());
+            final List<String> errorCode = codeErrors.stream()
+                .map(FieldError::getCode)
+                .collect(Collectors.toList());
+            if (errorCode.contains(NotEmpty.class.getSimpleName())) {
                 model.addAttribute("isCodeEmpty", true);
-            } else if (codeErrors.contains(Length.class.getSimpleName())) {
-                model.addAttribute("isCodeLengthInvalid", true);
-            } else if (codeErrors.contains(javax.validation.constraints.Pattern.class.getSimpleName())) {
+            } else if (errorCode.contains(Pattern.class.getSimpleName())) {
                 model.addAttribute("isCodePatternInvalid", true);
+            } else if (errorCode.contains(Length.class.getSimpleName())) {
+                model.addAttribute("isCodeLengthInvalid", true);
             }
             model.addAttribute(HAS_ERRORS, true);
             return new ModelAndView(VERIFICATION_VIEW, model.asMap());

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/model/VerificationRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/model/VerificationRequest.java
@@ -28,10 +28,13 @@ public class VerificationRequest {
 
     private boolean selfRegistrationEnabled;
 
+    @NotEmpty
+    @Pattern(regexp = "\\d+")
+    @Length(min = 8, max = 8)
     private String code;
 
-    @NotEmpty @Length(min = 6, max = 6) @Pattern(regexp = "\\d+")
-    public String getCode() {
-        return code != null ? code.trim() : null;
+    public void setCode(String code) {
+        this.code = code != null ? code.trim() : null;
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/model/VerificationRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/model/VerificationRequest.java
@@ -2,8 +2,10 @@ package uk.gov.hmcts.reform.idam.web.model;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
 
 @Setter
 @Getter
@@ -26,6 +28,10 @@ public class VerificationRequest {
 
     private boolean selfRegistrationEnabled;
 
-    @NotEmpty
     private String code;
+
+    @NotEmpty @Length(min = 6, max = 6) @Pattern(regexp = "\\d+")
+    public String getCode() {
+        return code != null ? code.trim() : null;
+    }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -137,7 +137,10 @@ public.login.error.failed.title=Incorrect email or password
 public.login.error.failed.username=Check your email address
 public.login.error.failed.password=Check your password
 public.login.error.verification.failed.title=Incorrect verification code
-public.login.error.verification.failed.code=Check your verification code
+public.login.error.verification.field.code.failed=Check your verification code
+public.login.error.verification.field.code.empty=Enter a verification code
+public.login.error.verification.field.code.pattern=Enter numbers only
+public.login.error.verification.field.code.length=Enter a valid verification code
 
 #One Time Password Verification
 public.verification.subheading.verification.required=Verification required
@@ -180,7 +183,6 @@ public.common.error.please.fix.following=Please fix the following
 public.common.error.enter.username=Enter your email address
 public.common.error.invalid.username=Your email address is invalid
 public.common.error.enter.password=Enter your password
-public.common.error.enter.code=Enter the verification code
 public.common.error.empty.first.name=Enter your first name
 public.common.error.invalid.first.name=Your first name is invalid
 public.common.error.empty.last.name=Enter your last name

--- a/src/main/webapp/WEB-INF/jsp/verification.jsp
+++ b/src/main/webapp/WEB-INF/jsp/verification.jsp
@@ -44,7 +44,19 @@
                                     <script>
                                         sendEvent('Authorization', 'Error', 'One time password is empty');
                                     </script>
-                                    <li><a href="#code"><form:errors path="code"/></a></li>
+                                    <li><a href="#code">empty</a></li>
+                                </c:if>
+                                <c:if test="${isCodeLengthInvalid}">
+                                    <script>
+                                        sendEvent('Authorization', 'Error', 'One time password has invalid length');
+                                    </script>
+                                    <li><a href="#code">length</a></li>
+                                </c:if>
+                                <c:if test="${isCodePatternInvalid}">
+                                    <script>
+                                        sendEvent('Authorization', 'Error', 'One time password has invalid pattern');
+                                    </script>
+                                    <li><a href="#code">pattern</a></li>
                                 </c:if>
                                 <c:if test="${hasLoginFailed}">
                                     <li><a href="#code"><spring:message code="public.login.error.verification.failed.code"/></a></li>

--- a/src/main/webapp/WEB-INF/jsp/verification.jsp
+++ b/src/main/webapp/WEB-INF/jsp/verification.jsp
@@ -19,72 +19,85 @@
             <form:input id="selfRegistrationEnabled" name="selfRegistrationEnabled" path="selfRegistrationEnabled" type="hidden" value="" />
 
             <spring:hasBindErrors name="authorizeCommand">
+                <c:set var="hasBindError" value="true" />
                 <script>
                     sendEvent('Authorization', 'Error', 'User one time password authorization has failed');
                 </script>
                 <div class="error-summary" role="group"
                      aria-labelledby="validation-error-summary-heading"
                      tabindex="-1">
-                    <c:choose>
-                        <c:when test="${hasOtpCheckFailed}">
-                            <h2 class="heading-medium error-summary-heading" id="validation-error-summary-heading">
+
+                    <h2 class="heading-medium error-summary-heading" id="validation-error-summary-heading">
+                        <c:choose>
+                            <c:when test="${hasOtpCheckFailed}">
                                 <spring:message code="public.login.error.verification.failed.title"/>
-                            </h2>
-                            <ul class="error-summary-list">
-                                <li><a href="#code"><spring:message code="public.login.error.verification.failed.code"/></a></li>
-                            </ul>
-                        </c:when>
-                        <c:otherwise>
-                            <h2 class="heading-medium error-summary-heading" id="validation-error-summary-heading">
+                            </c:when>
+                            <c:otherwise>
                                 <spring:message code="public.login.error.other.title"/>
-                            </h2>
-                            <p><spring:message code="public.common.error.please.fix.following"/></p>
-                            <ul class="error-summary-list">
-                                <c:if test="${isCodeEmpty}">
-                                    <script>
-                                        sendEvent('Authorization', 'Error', 'One time password is empty');
-                                    </script>
-                                    <li><a href="#code">empty</a></li>
-                                </c:if>
-                                <c:if test="${isCodeLengthInvalid}">
-                                    <script>
-                                        sendEvent('Authorization', 'Error', 'One time password has invalid length');
-                                    </script>
-                                    <li><a href="#code">length</a></li>
-                                </c:if>
-                                <c:if test="${isCodePatternInvalid}">
-                                    <script>
-                                        sendEvent('Authorization', 'Error', 'One time password has invalid pattern');
-                                    </script>
-                                    <li><a href="#code">pattern</a></li>
-                                </c:if>
-                                <c:if test="${hasLoginFailed}">
-                                    <li><a href="#code"><spring:message code="public.login.error.verification.failed.code"/></a></li>
-                                </c:if>
-                            </ul>
-                        </c:otherwise>
-                    </c:choose>
+                            </c:otherwise>
+                        </c:choose>
+                    </h2>
+                    <p><spring:message code="public.common.error.please.fix.following"/></p>
+                    <ul class="error-summary-list">
+                        <c:choose>
+                            <c:when test="${isCodeEmpty}">
+                                <script>
+                                    sendEvent('Authorization', 'Error', 'One time password is empty');
+                                </script>
+                                <li><a href="#code"><spring:message code="public.login.error.verification.field.code.empty"/></a></li>
+                            </c:when>
+                            <c:when test="${isCodePatternInvalid}">
+                                <script>
+                                    sendEvent('Authorization', 'Error', 'One time password has invalid pattern');
+                                </script>
+                                <li><a href="#code"><spring:message code="public.login.error.verification.field.code.pattern"/></a></li>
+                            </c:when>
+                            <c:when test="${isCodeLengthInvalid}">
+                                <script>
+                                    sendEvent('Authorization', 'Error', 'One time password has invalid length');
+                                </script>
+                                <li><a href="#code"><spring:message code="public.login.error.verification.field.code.length"/></a></li>
+                            </c:when>
+                            <c:otherwise>
+                                <script>
+                                    sendEvent('Authorization', 'Error', 'One time password is incorrect');
+                                </script>
+                                <li><a href="#code"><spring:message code="public.login.error.verification.field.code.failed"/></a></li>
+                            </c:otherwise>
+                        </c:choose>
+                    </ul>
                 </div>
             </spring:hasBindErrors>
 
             <h1 class="heading-large"><spring:message code="public.verification.subheading.verification.required"/></h1>
             <div class="form-section">
                 <p><spring:message code="public.verification.p"/></p>
-
-                <c:set var="codeError" value="${isCodeEmpty || hasOtpCheckFailed || hasLoginFailed}"/>
-                <div class="form-group ${codeError? 'form-group-error' : ''}">
+                <div class="form-group ${hasBindError? 'form-group-error' : ''}">
                     <label for="code">
                         <span class="form-label">
                             <spring:message code="public.verification.code.label"/>
                         </span>
                     </label>
-                    <c:if test="${isCodeEmpty}">
-                    <span class="error-message">
-                        <spring:message code="public.common.error.enter.code"/>
-                    </span>
+                    <c:if test="${hasBindError}">
+                        <span class="error-message">
+                            <c:choose>
+                                <c:when test="${isCodeEmpty}">
+                                    <spring:message code="public.login.error.verification.field.code.empty"/>
+                                </c:when>
+                                <c:when test="${isCodePatternInvalid}">
+                                    <spring:message code="public.login.error.verification.field.code.pattern"/>
+                                </c:when>
+                                <c:when test="${isCodeLengthInvalid}">
+                                    <spring:message code="public.login.error.verification.field.code.length"/>
+                                </c:when>
+                                <c:otherwise>
+                                    <spring:message code="public.login.error.verification.field.code.failed"/>
+                                </c:otherwise>
+                            </c:choose>
+                        </span>
                     </c:if>
                     <form:input
-                        class="form-control${codeError? ' form-control-error' : ''}"
+                        class="form-control${hasBindError? ' form-control-error' : ''}"
                         id="code" name="code" path="code" type="code" value="" autocomplete="off"/>
                 </div>
                 <input class="button" type="submit" value="<spring:message code="public.verification.form.submit" />">

--- a/src/test/java/uk/gov/hmcts/reform/idam/web/AppControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/web/AppControllerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.idam.web;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -1718,13 +1719,13 @@ public class AppControllerTest {
             .param(RESPONSE_TYPE_PARAMETER, RESPONSE_TYPE)
             .param(CLIENT_ID_PARAMETER, CLIENT_ID)
             .param(SCOPE_PARAMETER, CUSTOM_SCOPE)
-            .param(CODE_PARAMETER, "12345"))
+            .param(CODE_PARAMETER, "12345678"))
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl(REDIRECT_URI));
 
         verify(spiService).submitOtpeAuthentication(eq(singletonList("Idam.AuthId=authId")),
             eq(USER_IP_ADDRESS),
-            eq("12345"));
+            eq("12345678"));
 
         ArgumentCaptor<Map> paramsCaptor = ArgumentCaptor.forClass(Map.class);
         verify(spiService).authorize(paramsCaptor.capture(), eq(singletonList("Idam.Session=idamSessionCookie")));
@@ -1736,7 +1737,7 @@ public class AppControllerTest {
         assertThat(actualParams, hasEntry(RESPONSE_TYPE_PARAMETER, RESPONSE_TYPE));
         assertThat(actualParams, hasEntry(CLIENT_ID_PARAMETER, CLIENT_ID));
         assertThat(actualParams, hasEntry(SCOPE_PARAMETER, CUSTOM_SCOPE));
-        assertThat(actualParams, hasEntry(CODE_PARAMETER, "12345"));
+        assertThat(actualParams, hasEntry(CODE_PARAMETER, "12345678"));
     }
 
     /**
@@ -1760,14 +1761,14 @@ public class AppControllerTest {
             .param(RESPONSE_TYPE_PARAMETER, RESPONSE_TYPE)
             .param(CLIENT_ID_PARAMETER, CLIENT_ID)
             .param(SCOPE_PARAMETER, CUSTOM_SCOPE)
-            .param(CODE_PARAMETER, "12345"))
+            .param(CODE_PARAMETER, "12345678"))
             .andExpect(status().is2xxSuccessful())
             .andExpect(view().name(VERIFICATION_VIEW))
             .andExpect(model().attribute(MvcKeys.HAS_OTP_CHECK_FAILED, true));
 
         verify(spiService).submitOtpeAuthentication(eq(singletonList("Idam.AuthId=authId")),
             eq(USER_IP_ADDRESS),
-            eq("12345"));
+            eq("12345678"));
     }
 
     /**
@@ -1788,13 +1789,13 @@ public class AppControllerTest {
             .param(RESPONSE_TYPE_PARAMETER, RESPONSE_TYPE)
             .param(CLIENT_ID_PARAMETER, CLIENT_ID)
             .param(SCOPE_PARAMETER, CUSTOM_SCOPE)
-            .param(CODE_PARAMETER, "12345"))
+            .param(CODE_PARAMETER, "12345678"))
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrlPattern("login*"));
 
         verify(spiService).submitOtpeAuthentication(eq(singletonList("Idam.AuthId=authId")),
             eq(USER_IP_ADDRESS),
-            eq("12345"));
+            eq("12345678"));
     }
 
     /**
@@ -1815,13 +1816,13 @@ public class AppControllerTest {
             .param(RESPONSE_TYPE_PARAMETER, RESPONSE_TYPE)
             .param(CLIENT_ID_PARAMETER, CLIENT_ID)
             .param(SCOPE_PARAMETER, CUSTOM_SCOPE)
-            .param(CODE_PARAMETER, "12345"))
+            .param(CODE_PARAMETER, "12345678"))
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrlPattern("login*"));
 
         verify(spiService).submitOtpeAuthentication(eq(singletonList("Idam.AuthId=authId")),
             eq(USER_IP_ADDRESS),
-            eq("12345"));
+            eq("12345678"));
     }
 
     /**
@@ -1845,13 +1846,13 @@ public class AppControllerTest {
             .param(RESPONSE_TYPE_PARAMETER, RESPONSE_TYPE)
             .param(CLIENT_ID_PARAMETER, CLIENT_ID)
             .param(SCOPE_PARAMETER, CUSTOM_SCOPE)
-            .param(CODE_PARAMETER, "12345"))
+            .param(CODE_PARAMETER, "12345678"))
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrlPattern("login*"));
 
         verify(spiService).submitOtpeAuthentication(eq(singletonList("Idam.AuthId=authId")),
             eq(USER_IP_ADDRESS),
-            eq("12345"));
+            eq("12345678"));
 
         ArgumentCaptor<Map> paramsCaptor = ArgumentCaptor.forClass(Map.class);
         verify(spiService).authorize(paramsCaptor.capture(), eq(singletonList("Idam.Session=idamSessionCookie")));
@@ -1863,7 +1864,7 @@ public class AppControllerTest {
         assertThat(actualParams, hasEntry(RESPONSE_TYPE_PARAMETER, RESPONSE_TYPE));
         assertThat(actualParams, hasEntry(CLIENT_ID_PARAMETER, CLIENT_ID));
         assertThat(actualParams, hasEntry(SCOPE_PARAMETER, CUSTOM_SCOPE));
-        assertThat(actualParams, hasEntry(CODE_PARAMETER, "12345"));
+        assertThat(actualParams, hasEntry(CODE_PARAMETER, "12345678"));
     }
 
     /**
@@ -1932,5 +1933,80 @@ public class AppControllerTest {
             .andExpect(model().attribute(SCOPE_PARAMETER, CUSTOM_SCOPE))
             .andExpect(model().attribute(SELF_REGISTRATION_ENABLED, Boolean.TRUE))
             .andExpect(view().name(VERIFICATION_VIEW));
+    }
+
+    /**
+     * @verifies validate code field is not empty
+     * @see AppController#verification(uk.gov.hmcts.reform.idam.web.model.VerificationRequest, BindingResult, Model, HttpServletRequest, HttpServletResponse)
+     */
+    @Test
+    public void verification_shouldValidateCodeFieldIsNotEmpty() throws Exception {
+        mockMvc.perform(post(VERIFICATION_ENDPOINT).with(csrf())
+            .cookie(new Cookie("Idam.AuthId", "authId"))
+            .header(X_FORWARDED_FOR, USER_IP_ADDRESS)
+            .param(USERNAME_PARAMETER, USER_EMAIL)
+            .param(REDIRECT_URI, REDIRECT_URI)
+            .param(STATE_PARAMETER, STATE)
+            .param(RESPONSE_TYPE_PARAMETER, RESPONSE_TYPE)
+            .param(CLIENT_ID_PARAMETER, CLIENT_ID)
+            .param(SCOPE_PARAMETER, CUSTOM_SCOPE)
+            .param(CODE_PARAMETER, ""))
+            .andExpect(status().is2xxSuccessful())
+            .andExpect(view().name(VERIFICATION_VIEW))
+            .andExpect(model().attribute("isCodeEmpty", true));
+
+        verify(spiService, never()).submitOtpeAuthentication(any(),
+            any(),
+            any());
+    }
+
+    /**
+     * @verifies validate code field is digits
+     * @see AppController#verification(uk.gov.hmcts.reform.idam.web.model.VerificationRequest, BindingResult, Model, HttpServletRequest, HttpServletResponse)
+     */
+    @Test
+    public void verification_shouldValidateCodeFieldIsDigits() throws Exception {
+        mockMvc.perform(post(VERIFICATION_ENDPOINT).with(csrf())
+            .cookie(new Cookie("Idam.AuthId", "authId"))
+            .header(X_FORWARDED_FOR, USER_IP_ADDRESS)
+            .param(USERNAME_PARAMETER, USER_EMAIL)
+            .param(REDIRECT_URI, REDIRECT_URI)
+            .param(STATE_PARAMETER, STATE)
+            .param(RESPONSE_TYPE_PARAMETER, RESPONSE_TYPE)
+            .param(CLIENT_ID_PARAMETER, CLIENT_ID)
+            .param(SCOPE_PARAMETER, CUSTOM_SCOPE)
+            .param(CODE_PARAMETER, "a"))
+            .andExpect(status().is2xxSuccessful())
+            .andExpect(view().name(VERIFICATION_VIEW))
+            .andExpect(model().attribute("isCodePatternInvalid", true));
+
+        verify(spiService, never()).submitOtpeAuthentication(any(),
+            any(),
+            any());
+    }
+
+    /**
+     * @verifies validate code field is 8 digits
+     * @see AppController#verification(uk.gov.hmcts.reform.idam.web.model.VerificationRequest, BindingResult, Model, HttpServletRequest, HttpServletResponse)
+     */
+    @Test
+    public void verification_shouldValidateCodeFieldIs8Digits() throws Exception {
+        mockMvc.perform(post(VERIFICATION_ENDPOINT).with(csrf())
+            .cookie(new Cookie("Idam.AuthId", "authId"))
+            .header(X_FORWARDED_FOR, USER_IP_ADDRESS)
+            .param(USERNAME_PARAMETER, USER_EMAIL)
+            .param(REDIRECT_URI, REDIRECT_URI)
+            .param(STATE_PARAMETER, STATE)
+            .param(RESPONSE_TYPE_PARAMETER, RESPONSE_TYPE)
+            .param(CLIENT_ID_PARAMETER, CLIENT_ID)
+            .param(SCOPE_PARAMETER, CUSTOM_SCOPE)
+            .param(CODE_PARAMETER, "123"))
+            .andExpect(status().is2xxSuccessful())
+            .andExpect(view().name(VERIFICATION_VIEW))
+            .andExpect(model().attribute("isCodeLengthInvalid", true));
+
+        verify(spiService, never()).submitOtpeAuthentication(any(),
+            any(),
+            any());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/idam/web/AppControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/web/AppControllerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.idam.web;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-3248


### Change description ###
- code field trim
- code field validation: empty, numbers, length, incorrect
**as seen below**


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

<img width="1367" alt="Screenshot 2019-11-05 at 18 53 38" src="https://user-images.githubusercontent.com/50667636/68237145-80408980-fffe-11e9-8915-f24280d81e93.png"> normal |<img width="1367" alt="Screenshot 2019-11-05 at 18 53 43" src="https://user-images.githubusercontent.com/50667636/68237147-80408980-fffe-11e9-8256-7847cdb40841.png"> empty |<img width="1367" alt="Screenshot 2019-11-05 at 18 53 53" src="https://user-images.githubusercontent.com/50667636/68237148-80d92000-fffe-11e9-9cc9-e3bf993f231a.png"> number
:---:|:---:|:---:
<img width="1367" alt="Screenshot 2019-11-05 at 18 54 03" src="https://user-images.githubusercontent.com/50667636/68237149-80d92000-fffe-11e9-822e-1d90f8daae74.png"> **length** |<img width="1367" alt="Screenshot 2019-11-05 at 18 54 39" src="https://user-images.githubusercontent.com/50667636/68237151-80d92000-fffe-11e9-91c8-f350e79f5f68.png">**incorrect** |<img width="1367" alt="Screenshot 2019-11-05 at 18 55 37" src="https://user-images.githubusercontent.com/50667636/68237152-8171b680-fffe-11e9-9dac-c7ccda8c36cf.png"> **3x incorrect**
