### PR TITLE
[v1.5.1] feat(SIDM-3128-survey): add pageurl parameter to smartsurvey link

### DIFF
--- a/src/main/webapp/WEB-INF/tags/wrapper.tag
+++ b/src/main/webapp/WEB-INF/tags/wrapper.tag
@@ -121,10 +121,15 @@
             <p>
                 <strong class="phase-tag"><spring:message code="public.template.header.phase.tag" /></strong>
                 <span>
+                    <c:set var="smartSurveyUrl">
+                        <spring:url value="https://www.smartsurvey.co.uk/s/IDAMSurvey/">
+                            <spring:param name="pageurl" value="${pageContext.request.requestURL}${empty pageContext.request.queryString ? '' : '?'}${pageContext.request.queryString}" />
+                        </spring:url>
+                    </c:set>
                     <spring:message
                         htmlEscape="false"
                         code="public.template.header.phase.description"
-                        arguments="https://www.smartsurvey.co.uk/s/IDAMSurvey/"
+                        arguments="${smartSurveyUrl}"
                     />
                 </span>
             </p>


### PR DESCRIPTION
### MERGING INTO 1.5.1 BRANCH ###

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-3128


### Change description ###
Add pageurl parameter to the smartsurvey link using JSP tags only and escaping url


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
