### PR TITLE
feat(SIDM-3248-val5): otp: fix multiple policies and sensitive data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,9 @@ allprojects  {
   sourceCompatibility = 1.8
   targetCompatibility = 1.8
 
-  def idamBomVersion = '1.7.2'
+  def idamBomVersion = '1.9.0'
   ext['tomcat.version'] = '9.0.22'
-  
+
   dependencyManagement {
     imports {
       mavenBom "uk.gov.hmcts.reform.idam:idam-bom:${idamBomVersion}"

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/AppController.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/AppController.java
@@ -465,6 +465,7 @@ public class AppController {
      * @should submit otp authentication using authId cookie and otp code then call authorise and redirect the user
      * @should submit otp authentication filtering out Idam.Session cookie to avoid session bugs
      * @should return verification view for INCORRECT_OTP 401 response
+     * @should return login view for TOO_MANY_ATTEMPTS_OTP 401 response
      * @should return verification view for expired OTP session 401 response
      * @should return login view for 403 response
      * @should return login view when authorize fails
@@ -546,6 +547,12 @@ public class AppController {
                     return new ModelAndView(VERIFICATION_VIEW, model.asMap());
                 }
 
+                // if 3x failed
+                if (ErrorResponse.CodeEnum.TOO_MANY_ATTEMPTS_OTP.equals(error.getCode())) {
+                    return redirectToLoginOnFailedOtpVerification(request, bindingResult, model);
+                }
+
+                // if expired
                 bindingResult.reject("Expired OTP");
                 model.addAttribute(HAS_OTP_SESSION_EXPIRED, true);
                 return new ModelAndView(VERIFICATION_VIEW, model.asMap());

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/strategic/PolicyService.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/strategic/PolicyService.java
@@ -67,6 +67,7 @@ public class PolicyService {
      * @should return ALLOW when actions is null
      * @should return MFA_REQUIRED when any action returns false and attribute mfaRequired is true
      * @should return BLOCK when any action returns false and attribute mfaRequired is not true
+     * @should return BLOCK when any action returns false and attribute mfaRequired is true but there are other attributes
      * @should throw exception when response is not successful
      */
     public EvaluatePoliciesAction evaluatePoliciesForUser(final String uri, final List<String> cookies, final String ipAddress) {
@@ -130,10 +131,12 @@ public class PolicyService {
                 final boolean hasAttributes = resultItem.getAttributes() != null && resultItem.getAttributes() instanceof Map;
                 final boolean mfaRequiredAttributeIsTrue = hasAttributes && asList(ADVICE_KEY_MFA_REQUIRED_STRING_VALUE)
                     .equals(((Map) resultItem.getAttributes()).get(ADVICE_KEY_MFA_REQUIRED));
+                final boolean hasOnlyMfaRequiredAttribute = mfaRequiredAttributeIsTrue
+                    && ((Map) resultItem.getAttributes()).size() == 1;
 
                 // if mfaRequired we downgrade action to mfa_required but still need to check for other possible
                 // actions blocking the user even with mfa
-                if (mfaRequiredAttributeIsTrue) {
+                if (mfaRequiredAttributeIsTrue && hasOnlyMfaRequiredAttribute) {
                     action = EvaluatePoliciesAction.MFA_REQUIRED;
                 } else {
                     return EvaluatePoliciesAction.BLOCK;

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -137,8 +137,9 @@ public.login.error.failed.title=Incorrect email or password
 public.login.error.failed.username=Check your email address
 public.login.error.failed.password=Check your password
 public.login.error.verification.failed.title=Incorrect verification code
+public.login.error.verification.expired.title=There is a problem with the code you entered
 public.login.error.verification.field.code.failed=Verification code incorrect, try again
-public.login.error.verification.field.code.expired=This verification code has expired, go back and login again
+public.login.error.verification.field.code.expired=This verification code has expired, go back and <a href="{0}">login</a> again
 public.login.error.verification.field.code.empty=Enter a verification code
 public.login.error.verification.field.code.pattern=Enter numbers only
 public.login.error.verification.field.code.length=Enter a valid verification code

--- a/src/main/webapp/WEB-INF/jsp/verification.jsp
+++ b/src/main/webapp/WEB-INF/jsp/verification.jsp
@@ -32,49 +32,68 @@
                             <c:when test="${hasOtpCheckFailed}">
                                 <spring:message code="public.login.error.verification.failed.title"/>
                             </c:when>
+                            <c:when test="${hasOtpSessionExpired}">
+                                <spring:message code="public.login.error.verification.expired.title"/>
+                            </c:when>
                             <c:otherwise>
                                 <spring:message code="public.login.error.other.title"/>
                             </c:otherwise>
                         </c:choose>
                     </h2>
-                    <p><spring:message code="public.common.error.please.fix.following"/></p>
-                    <ul class="error-summary-list">
-                        <c:choose>
-                            <c:when test="${isCodeEmpty}">
-                                <script>
-                                    sendEvent('Authorization', 'Error', 'One time password is empty');
-                                </script>
+                    <c:choose>
+                        <c:when test="${isCodeEmpty}">
+                            <script>
+                                sendEvent('Authorization', 'Error', 'One time password is empty');
+                            </script>
+                            <p><spring:message code="public.common.error.please.fix.following"/></p>
+                            <ul class="error-summary-list">
                                 <li><a href="#code"><spring:message code="public.login.error.verification.field.code.empty"/></a></li>
-                            </c:when>
-                            <c:when test="${isCodePatternInvalid}">
-                                <script>
-                                    sendEvent('Authorization', 'Error', 'One time password has invalid pattern');
-                                </script>
+                            </ul>
+                        </c:when>
+                        <c:when test="${isCodePatternInvalid}">
+                            <script>
+                                sendEvent('Authorization', 'Error', 'One time password has invalid pattern');
+                            </script>
+                            <p><spring:message code="public.common.error.please.fix.following"/></p>
+                            <ul class="error-summary-list">
                                 <li><a href="#code"><spring:message code="public.login.error.verification.field.code.pattern"/></a></li>
-                            </c:when>
-                            <c:when test="${isCodeLengthInvalid}">
-                                <script>
-                                    sendEvent('Authorization', 'Error', 'One time password has invalid length');
-                                </script>
+                            </ul>
+                        </c:when>
+                        <c:when test="${isCodeLengthInvalid}">
+                            <script>
+                                sendEvent('Authorization', 'Error', 'One time password has invalid length');
+                            </script>
+                            <p><spring:message code="public.common.error.please.fix.following"/></p>
+                            <ul class="error-summary-list">
                                 <li><a href="#code"><spring:message code="public.login.error.verification.field.code.length"/></a></li>
-                            </c:when>
-                            <c:when test="${hasOtpSessionExpired}">
-                                <script>
-                                    sendEvent('Authorization', 'Error', 'One time password has expired');
-                                </script>
-                                <c:set var="loginUrl">
-                                    <spring:url value="/login?${pageContext.request.queryString}" />
-                                </c:set>
-                                <li><a href="${loginUrl}"><spring:message code="public.login.error.verification.field.code.expired"/></a></li>
-                            </c:when>
-                            <c:otherwise>
-                                <script>
-                                    sendEvent('Authorization', 'Error', 'One time password is incorrect');
-                                </script>
+                            </ul>
+                        </c:when>
+                        <c:when test="${hasOtpSessionExpired}">
+                            <script>
+                                sendEvent('Authorization', 'Error', 'One time password has expired');
+                            </script>
+                            <c:set var="loginUrl">
+                                <spring:url value="/login?${pageContext.request.queryString}" />
+                            </c:set>
+                            <div class="text">
+                                <p>
+                                    <spring:message
+                                        code="public.login.error.verification.field.code.expired"
+                                        arguments="${loginUrl}"
+                                        htmlEscape="false"/>
+                                </p>
+                            </div>
+                        </c:when>
+                        <c:otherwise>
+                            <script>
+                                sendEvent('Authorization', 'Error', 'One time password is incorrect');
+                            </script>
+                            <p><spring:message code="public.common.error.please.fix.following"/></p>
+                            <ul class="error-summary-list">
                                 <li><a href="#code"><spring:message code="public.login.error.verification.field.code.failed"/></a></li>
-                            </c:otherwise>
-                        </c:choose>
-                    </ul>
+                            </ul>
+                        </c:otherwise>
+                    </c:choose>
                 </div>
             </spring:hasBindErrors>
 
@@ -100,7 +119,10 @@
                                     <spring:message code="public.login.error.verification.field.code.length"/>
                                 </c:when>
                                 <c:when test="${hasOtpSessionExpired}">
-                                    <spring:message code="public.login.error.verification.field.code.expired"/>
+                                    <c:set var="loginUrl">
+                                        <spring:url value="/login?${pageContext.request.queryString}" />
+                                    </c:set>
+                                    <spring:message code="public.login.error.verification.field.code.expired" htmlEscape="false" arguments="${loginUrl}"/>
                                 </c:when>
                                 <c:otherwise>
                                     <spring:message code="public.login.error.verification.field.code.failed"/>

--- a/src/main/webapp/WEB-INF/jsp/verification.jsp
+++ b/src/main/webapp/WEB-INF/jsp/verification.jsp
@@ -62,7 +62,10 @@
                                 <script>
                                     sendEvent('Authorization', 'Error', 'One time password has expired');
                                 </script>
-                                <li><a href="#code"><spring:message code="public.login.error.verification.field.code.expired"/></a></li>
+                                <c:set var="loginUrl">
+                                    <spring:url value="/login?${pageContext.request.queryString}" />
+                                </c:set>
+                                <li><a href="${loginUrl}"><spring:message code="public.login.error.verification.field.code.expired"/></a></li>
                             </c:when>
                             <c:otherwise>
                                 <script>

--- a/src/test/java/uk/gov/hmcts/reform/idam/web/AppControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/web/AppControllerTest.java
@@ -1772,6 +1772,41 @@ public class AppControllerTest {
     }
 
     /**
+     * @verifies return login view for TOO_MANY_ATTEMPTS_OTP 401 response
+     * @see AppController#verification(uk.gov.hmcts.reform.idam.web.model.VerificationRequest, BindingResult, Model, HttpServletRequest, HttpServletResponse)
+     */
+    @Test
+    public void verification_shouldReturnLoginViewForTOO_MANY_ATTEMPTS_OTP401Response() throws Exception {
+        given(spiService.submitOtpeAuthentication(any(), any(), any()))
+            .willReturn(singletonList("Idam.Session=idamSessionCookie"));
+
+        given(spiService.submitOtpeAuthentication(any(), any(), any()))
+            .willThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED,
+                "statusText",
+                "{\"code\":\"TOO_MANY_ATTEMPTS_OTP\"}".getBytes(StandardCharsets.UTF_8),
+                StandardCharsets.UTF_8));
+
+        mockMvc.perform(post(VERIFICATION_ENDPOINT).with(csrf())
+            .cookie(new Cookie("Idam.AuthId", "authId"))
+            .header(X_FORWARDED_FOR, USER_IP_ADDRESS)
+            .param(USERNAME_PARAMETER, USER_EMAIL)
+            .param(REDIRECT_URI, REDIRECT_URI)
+            .param(STATE_PARAMETER, STATE)
+            .param(RESPONSE_TYPE_PARAMETER, RESPONSE_TYPE)
+            .param(CLIENT_ID_PARAMETER, CLIENT_ID)
+            .param(SCOPE_PARAMETER, CUSTOM_SCOPE)
+            .param(CODE_PARAMETER, "12345678"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrlPattern("login*"));
+
+        verify(spiService).submitOtpeAuthentication(eq(singletonList("Idam.AuthId=authId")),
+            eq(USER_IP_ADDRESS),
+            eq("12345678"));
+
+        verify(spiService, never()).authorize(any(), any());
+    }
+
+    /**
      * @verifies return verification view for expired OTP session 401 response
      * @see AppController#verification(uk.gov.hmcts.reform.idam.web.model.VerificationRequest, BindingResult, Model, HttpServletRequest, HttpServletResponse)
      */


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-3248
https://tools.hmcts.net/jira/browse/SIDM-3294


### Change description ###
- remove username password from redirect to /verification
- when mfaRequired also check if there are other attributes meaning other policies are also blocking this user
- add link to login page on expired otp code

![Screenshot 2019-11-08 at 12 29 16](https://user-images.githubusercontent.com/50667636/68476987-24574a00-0224-11ea-85e6-c232685a9804.png) |
--- |

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
