### PR TITLE
feat(SIDM-3248-duplicate-params): fix duplicate params

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/verification.jsp
+++ b/src/main/webapp/WEB-INF/jsp/verification.jsp
@@ -14,12 +14,6 @@
                    novalidate=""
                    _lpchecked="1">
 
-            <form:input id="response_type" name="response_type" path="response_type" type="hidden" value="${response_type}" />
-            <form:input id="state" name="state" path="state" type="hidden" value="${state}" />
-            <form:input id="client_id" name="client_id" path="client_id" type="hidden" value="${client_id}" />
-            <form:input id="redirect_uri" name="redirect_uri" path="redirect_uri" type="hidden" value="${redirect_uri}" />
-            <form:input id="scope" name="scope" path="scope" type="hidden" value="${scope}" />
-
             <spring:hasBindErrors name="authorizeCommand">
                 <c:set var="hasBindError" value="true" />
                 <script>


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
issue:
on three times incorrect otp
then redirect to login had duplicate params as in `service=serviceName,serviceName`
which would cause the login to fail

see screenshot
<img width="1367" alt="Screenshot 2019-11-08 at 17 44 13" src="https://user-images.githubusercontent.com/50667636/68500239-1371fd00-0253-11ea-8bc4-2d9cf3c916c5.png">



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
