### PR TITLE
feat(SIDM-3410-ips): filter out internal ips from policy valuation (#…

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/web/config/properties/StrategicConfigurationProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/config/properties/StrategicConfigurationProperties.java
@@ -4,6 +4,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import lombok.Data;
 
+import java.util.regex.Pattern;
+
 @ConfigurationProperties(prefix = "strategic")
 @Data
 public class StrategicConfigurationProperties {
@@ -45,6 +47,7 @@ public class StrategicConfigurationProperties {
     @Data
     public static class Policies {
         private String applicationName;
+        private Pattern privateIpsFilterPattern;
     }
 
     @Data

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/strategic/PolicyService.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/strategic/PolicyService.java
@@ -69,6 +69,7 @@ public class PolicyService {
      * @should return BLOCK when any action returns false and attribute mfaRequired is not true
      * @should return BLOCK when any action returns false and attribute mfaRequired is true but there are other attributes
      * @should throw exception when response is not successful
+     * @should filter out internal ips from request
      */
     public EvaluatePoliciesAction evaluatePoliciesForUser(final String uri, final List<String> cookies, final String ipAddress) {
         final String applicationName = configurationProperties.getStrategic().getPolicies().getApplicationName();
@@ -80,11 +81,14 @@ public class PolicyService {
 
         final String userSsoToken = StringUtils.substringAfter(sessionCookie, "=");
 
+
+        final Pattern privateIpsFilterPattern = configurationProperties.getStrategic().getPolicies().getPrivateIpsFilterPattern();
+        final List<String> requestIp = sanitiseIpsFromRequestExcludingInternalIps(privateIpsFilterPattern, ipAddress);
         final EvaluatePoliciesRequest request = new EvaluatePoliciesRequest()
             .resources(singletonList(uri))
             .application(applicationName)
             .subject(new Subject().ssoToken(userSsoToken))
-            .environment(ImmutableMap.of("requestIp", sanitiseIpsFromRequest(ipAddress)));
+            .environment(ImmutableMap.of("requestIp", requestIp));
 
         final ResponseEntity<EvaluatePoliciesResponse> response = doEvaluatePolicies(cookies, userSsoToken, request, ipAddress);
 
@@ -147,7 +151,8 @@ public class PolicyService {
     }
 
     /**
-     * Sanitise and returns request ips in a list of strings
+     * Sanitise and returns first request ip in a list
+     *
      * Examples:
      * "1.1.1.1" => ["1.1.1.1"]
      * "51.140.12.192:59286" => ["51.140.12.192"]
@@ -155,9 +160,23 @@ public class PolicyService {
      * "2001:db8:85a3:8d3:1319:8a2e:370:7348" => ["2001:db8:85a3:8d3:1319:8a2e:370:7348"]
      * "[2001:db8:85a3:8d3:1319:8a2e:370:7348]:1234" => ["2001:db8:85a3:8d3:1319:8a2e:370:7348"]
      *
+     * Internal IPs Filter: "10.\d+\.\d+\.\d+"
+     * ["7.7.7.7"] => ["7.7.7.7"]
+     * ["10.0.0.0","7.7.7.7"] => ["7.7.7.7"]
+     * ["10.0.0.0","2001:db8:85a3:8d3:1319:8a2e:370:7348"] => ["2001:db8:85a3:8d3:1319:8a2e:370:7348"]
+     * ["2001:db8:85a3:8d3:1319:8a2e:370:7348","7.7.7.7"] => ["2001:db8:85a3:8d3:1319:8a2e:370:7348"]
+     *
+     * This filter was created to workaround a bug in FR
+     * where FR selects a random IP from the list to validate against the policy
+     *
+     * Our idea is to filter out our proxy IPs and select the first IP from the list
+     * According to the spec, X-FORWARDED-FOR should have the client IP as the first IP on the list
+     * To be extra safe we will also filter out our private IPs (10.x.x.x) from the list
+     *
      * @should break multiple ips and remove port
+     * @should filter out internal IPs
      */
-    protected List<String> sanitiseIpsFromRequest(String ipAddress) {
+    protected List<String> sanitiseIpsFromRequestExcludingInternalIps(Pattern internalIpsPattern, String ipAddress) {
         if (ipAddress == null) {
             return null;
         }
@@ -177,6 +196,8 @@ public class PolicyService {
                 }
                 return s;
             })
+            .filter(s -> ofNullable(internalIpsPattern).map(p -> !p.matcher(s).matches()).orElse(true))
+            .limit(1)
             .collect(Collectors.toList());
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -79,6 +79,7 @@ strategic:
     evaluatePolicies: api/v1/policies/evaluate
   policies:
     applicationName: HmctsPolicySet
+    privateIpsFilterPattern: "10\\.\\d+\\.\\d+\\.\\d+"
   session:
     idamSessionCookie: Idam.Session
 


### PR DESCRIPTION
…270)

* feat(SIDM-3410-ips): filter out internal ips from policy valuation

* feat(SIDM-3410-ips): simplify and merge methods

* feat(SIDM-3410-ips): simplify regex

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-3410


### Change description ###
MERGING THE WORK DONE FOR 1.5.RC into PREVIEW

Policy evaluation: filter internal ips using pattern 10.x.x.x and send only one IP for evaluation

Effect:
When X-FORWARDED-FOR: "10.0.0.1,7.7.7.7"
Then EvaluatePolicy with requestIp: ["7.7.7.7"]

Reason:
There's a bug in FR where it randomly picks ONE IP from the list to evaluate policies against,
Resulting in inconsistent responses

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
