### PR TITLE
feat(SIDM-3437-redir): login/mfa: redirecting using slash

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/idam/web/AppControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/web/AppControllerTest.java
@@ -1723,7 +1723,7 @@ public class AppControllerTest {
             .param(SCOPE_PARAMETER, CUSTOM_SCOPE))
             .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.SET_COOKIE, "Idam.AuthId=authIdCookie; Path=/; Secure; HttpOnly"))
             .andExpect(status().is3xxRedirection())
-            .andExpect(redirectedUrlPattern("verification*"));
+            .andExpect(redirectedUrlPattern("/verification*"));
 
         verify(spiService, never()).authorize(any(), eq(singletonList(AUTHENTICATE_SESSION_COOKE)));
 
@@ -1831,7 +1831,7 @@ public class AppControllerTest {
             .param(SCOPE_PARAMETER, CUSTOM_SCOPE)
             .param(CODE_PARAMETER, "12345678"))
             .andExpect(status().is3xxRedirection())
-            .andExpect(redirectedUrlPattern("login*"));
+            .andExpect(redirectedUrlPattern("/login*"));
 
         verify(spiService).submitOtpeAuthentication(eq(singletonList("Idam.AuthId=authId")),
             eq(USER_IP_ADDRESS),
@@ -1887,7 +1887,7 @@ public class AppControllerTest {
             .param(SCOPE_PARAMETER, CUSTOM_SCOPE)
             .param(CODE_PARAMETER, "12345678"))
             .andExpect(status().is3xxRedirection())
-            .andExpect(redirectedUrlPattern("login*"));
+            .andExpect(redirectedUrlPattern("/login*"));
 
         verify(spiService).submitOtpeAuthentication(eq(singletonList("Idam.AuthId=authId")),
             eq(USER_IP_ADDRESS),
@@ -1917,7 +1917,7 @@ public class AppControllerTest {
             .param(SCOPE_PARAMETER, CUSTOM_SCOPE)
             .param(CODE_PARAMETER, "12345678"))
             .andExpect(status().is3xxRedirection())
-            .andExpect(redirectedUrlPattern("login*"));
+            .andExpect(redirectedUrlPattern("/login*"));
 
         verify(spiService).submitOtpeAuthentication(eq(singletonList("Idam.AuthId=authId")),
             eq(USER_IP_ADDRESS),
@@ -2133,7 +2133,7 @@ public class AppControllerTest {
             .param(SCOPE_PARAMETER, CUSTOM_SCOPE))
             .andExpect(MockMvcResultMatchers.header().string(HttpHeaders.SET_COOKIE, "Idam.AuthId=authIdCookie; Path=/; Secure; HttpOnly"))
             .andExpect(status().is3xxRedirection())
-            .andExpect(redirectedUrlPattern("verification*"))
+            .andExpect(redirectedUrlPattern("/verification*"))
             .andExpect(model().attributeDoesNotExist(USERNAME))
             .andExpect(model().attributeDoesNotExist(PASSWORD))
             .andExpect(model().attributeDoesNotExist(MvcKeys.SELF_REGISTRATION_ENABLED))


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-3437


### Change description ###
Issue:
When user access page: "/login/?service=a&redirect=b"
And mfa is required
And we are using "redirect:verification"
Then user would get "/login/verification?service=a&redirect=b"

That happens because the redirect was context based.

Solution:
Use "redirect:/verification"
Manually tested in my local setup with success

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
