### PR TITLE
feat(SIDM-3441-sso): Policy eval: remove bearer auth token

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/web/strategic/PolicyService.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/strategic/PolicyService.java
@@ -89,7 +89,7 @@ public class PolicyService {
             .subject(new Subject().ssoToken(userSsoToken))
             .environment(ImmutableMap.of("requestIp", requestIp));
 
-        final ResponseEntity<EvaluatePoliciesResponse> response = doEvaluatePolicies(cookies, userSsoToken, request, ipAddress);
+        final ResponseEntity<EvaluatePoliciesResponse> response = doEvaluatePolicies(cookies, request, ipAddress);
 
         if (!response.getStatusCode().is2xxSuccessful()) {
             throw new HttpClientErrorException(response.getStatusCode(), ERROR_POLICY_CHECK_EXCEPTION);
@@ -100,14 +100,12 @@ public class PolicyService {
     }
 
     private ResponseEntity<EvaluatePoliciesResponse> doEvaluatePolicies(final List<String> cookies,
-                                                                        final String userSsoToken,
                                                                         final EvaluatePoliciesRequest request,
                                                                         final String ipAddress) {
         final HttpHeaders headers = new HttpHeaders();
         headers.add(X_FORWARDED_FOR, ipAddress);
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.put(HttpHeaders.COOKIE, cookies);
-        headers.setBearerAuth(userSsoToken);
 
         final HttpEntity<EvaluatePoliciesRequest> httpEntity = new HttpEntity<>(request, headers);
         final String url = String.format("%s/%s",

--- a/src/test/java/uk/gov/hmcts/reform/idam/web/strategic/PolicyServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/web/strategic/PolicyServiceTest.java
@@ -85,7 +85,6 @@ public class PolicyServiceTest {
         headers.put("X-Forwarded-For", singletonList(ipAddress));
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.put(HttpHeaders.COOKIE, singletonList(String.format("%s=%s", IDAM_SESSION_COOKIE_NAME, token)));
-        headers.setBearerAuth(token);
         return headers;
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-3441


### Change description ###
RC BRANCH
PolicyService#evaluate: don't set auth bearer token when calling policies/evaluate


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
