### PR TITLE
feat(sidm-3410-rc2): merge 3410 preview into RC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 target/
 !.mvn/wrapper/maven-wrapper.jar
 functional-output/
+
 ### STS ###
 .apt_generated
 .classpath
@@ -30,6 +31,12 @@ out
 output/
 
 **/application-local.yaml
+
+### VS Code ###
+bin
+
+### Terraform ###
+.terraform
 
 ### Helm ###
 **/charts/*.tgz

--- a/infrastructure/idam-preview.tfvars
+++ b/infrastructure/idam-preview.tfvars
@@ -5,3 +5,5 @@ asp_name_override = "idam-idam-preview"
 asp_rg_override = "idam-idam-preview"
 
 capacity = 1
+
+vnet_private_ip_pattern = "10\\.97\\.\\d+\\.\\d+"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -61,5 +61,7 @@ module "idam-web-public" {
     STRATEGIC_SERVICE_URL         = "${local.idam_api_url}"
 
     GA_TRACKING_ID                = "${var.ga_tracking_id}"
+
+    STRATEGIC_POLICIES_PRIVATEIPSFILTERPATTERN = "${var.vnet_private_ip_pattern}"
   }
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -81,5 +81,5 @@ variable vault_name_override {
 
 variable "vnet_private_ip_pattern" {
   description = "Private VNet IP Filter Pattern for Policies Evaluation"
-  default     = "10\\.\\d+\\.\\d+\\.\\d+"
+  default     = "10\\\\.\\\\d+\\\\.\\\\d+\\\\.\\\\d+"
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -78,3 +78,8 @@ variable vault_name_override {
   description = "Vault Name"
   default = ""
 }
+
+variable "vnet_private_ip_pattern" {
+  description = "Private VNet IP Filter Pattern for Policies Evaluation"
+  default     = "10\\.\\d+\\.\\d+\\.\\d+"
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -81,5 +81,5 @@ variable vault_name_override {
 
 variable "vnet_private_ip_pattern" {
   description = "Private VNet IP Filter Pattern for Policies Evaluation"
-  default     = "10\\\\.\\\\d+\\\\.\\\\d+\\\\.\\\\d+"
+  default     = "10\\.\\d+\\.\\d+\\.\\d+"
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-3410

### Change description ###
Merging 3410 PRs into RC:
https://github.com/hmcts/idam-web-public/pull/270
https://github.com/hmcts/idam-web-public/pull/272
https://github.com/hmcts/idam-web-public/pull/273
https://github.com/hmcts/idam-web-public/pull/281
https://github.com/hmcts/idam-web-public/pull/285

### Notes ###
We've noticed that the following config worked in preview: `"10\\.97\\.\\d+\\.\\d+"`
So we changed the default config escaping from `\\\\` to `\\` in #285 

### Previous notes ###
I'm worried about having both patterns in:
`"10\\.97\\.\\d+\\.\\d+"`
and
`"10\\\\.\\\\d+\\\\.\\\\d+\\\\.\\\\d+"`

Confirming this works in preview as is:
```

11/20/2019, 4:37:43.705 PM | EVALUATE_POLICY | customEvent | {"environment":"{requestIp=[10.96.4.97]}","sso
-- | -- | -- | --


```

This is what we currently have in preview, which seems to work, so I'm guessing the first one:
<img width="589" alt="Screenshot 2019-11-20 at 16 36 39" src="https://user-images.githubusercontent.com/50667636/69258188-1f937e00-0bb4-11ea-883d-31d6762d63de.png">


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
