### PR TITLE
feat(SIDM-3410-fix-def): use same escaping as preview which is tested

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -81,5 +81,5 @@ variable vault_name_override {
 
 variable "vnet_private_ip_pattern" {
   description = "Private VNet IP Filter Pattern for Policies Evaluation"
-  default     = "10\\\\.\\\\d+\\\\.\\\\d+\\\\.\\\\d+"
+  default     = "10\\.\\d+\\.\\d+\\.\\d+"
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-3410


### Change description ###
Use same escaping as preview which is working

Logs:
```
11/20/2019, 4:37:43.705 PM | EVALUATE_POLICY | customEvent | {"environment":"{requestIp=[10.96.4.97]}","sso
```

Sshot:
<img width="589" alt="Screenshot 2019-11-20 at 16 36 39" src="https://user-images.githubusercontent.com/50667636/69259472-3935c500-0bb6-11ea-8928-3d2ae5f844bb.png">



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
