### PR TITLE
feat(SIDM-3128-surveyfix): fix survey url and allow only client_id param

### DIFF
--- a/src/main/webapp/WEB-INF/tags/wrapper.tag
+++ b/src/main/webapp/WEB-INF/tags/wrapper.tag
@@ -121,9 +121,12 @@
             <p>
                 <strong class="phase-tag"><spring:message code="public.template.header.phase.tag" /></strong>
                 <span>
+                    <c:set var="smartSurveyParam">
+                        ${pageContext.request.scheme}://${pageContext.request.serverName}${requestScope['javax.servlet.forward.request_uri']}${empty param.client_id ? '' : '?client_id='}${param.client_id}
+                    </c:set>
                     <c:set var="smartSurveyUrl">
                         <spring:url value="https://www.smartsurvey.co.uk/s/IDAMSurvey/">
-                            <spring:param name="pageurl" value="${pageContext.request.requestURL}${empty pageContext.request.queryString ? '' : '?'}${pageContext.request.queryString}" />
+                            <spring:param name="pageurl" value="${smartSurveyParam}" />
                         </spring:url>
                     </c:set>
                     <spring:message


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-3128


### Change description ###
Remove /WEB-INF/jsp from url param
Only add client_id param as per Krem's comment https://tools.hmcts.net/jira/browse/SIDM-3128?focusedCommentId=672788&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-672788


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
