### PR TITLE
fix unknown char in email links

### DIFF
--- a/src/test/js/shared/idam_helper.js
+++ b/src/test/js/shared/idam_helper.js
@@ -476,7 +476,7 @@ class IdamHelper extends Helper {
             const regex = "(https.+)"
             const url = emailResponse.body.match(regex);
             if (url[0]) {
-                return url[0].replace(/https:\/\/idam-web-public\..+?\.platform\.hmcts\.net/i, TestData.WEB_PUBLIC_URL);
+                return url[0].replace(/https:\/\/idam-web-public\..+?\.platform\.hmcts\.net/i, TestData.WEB_PUBLIC_URL).replace(")", "");
             }
         }
     }


### PR DESCRIPTION
Fix unknown char ) in notify email links.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
