### PR TITLE
SIDM-5259 Removing the swagger ui dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,10 @@ allprojects {
   }
 
   dependencies {
-    implementation group: 'uk.gov.hmcts.reform.idam', name: 'idam-api-spec'
+    implementation (group: 'uk.gov.hmcts.reform.idam', name: 'idam-api-spec') {
+      exclude module: 'springfox-swagger2'
+      exclude module: 'springfox-swagger-ui'
+    }
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security'


### PR DESCRIPTION
SecOps found that we had transitively pulled in swagger-ui so we had a broken swagger ui page.