### PR TITLE
Welsh - fix AKS languages

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/web/config/MessagesConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/config/MessagesConfiguration.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.idam.web.config;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.LocaleResolver;
@@ -7,6 +8,8 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.i18n.CookieLocaleResolver;
 import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
+import uk.gov.hmcts.reform.idam.web.config.properties.ConfigurationProperties;
+import uk.gov.hmcts.reform.idam.web.config.properties.StrategicConfigurationProperties;
 
 @Configuration
 public class MessagesConfiguration implements WebMvcConfigurer {
@@ -16,6 +19,9 @@ public class MessagesConfiguration implements WebMvcConfigurer {
 
     /** A 10 years worth of expiration time for the locale cookie. */
     private static final Integer COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365 * 10;
+
+    @Autowired
+    private ConfigurationProperties configurationProperties;
 
     @Bean
     public LocaleResolver localeResolver() {
@@ -27,7 +33,7 @@ public class MessagesConfiguration implements WebMvcConfigurer {
 
     @Bean
     public LocaleChangeInterceptor localeChangeInterceptor() {
-        final LocaleChangeInterceptor interceptor = new OIDCLocaleChangeInterceptor();
+        final LocaleChangeInterceptor interceptor = new OIDCLocaleChangeInterceptor(configurationProperties.getStrategic().getLanguage().getSupportedLocales());
         interceptor.setParamName(UI_LOCALES_PARAM_NAME);
         interceptor.setIgnoreInvalidLocale(true);
         return interceptor;

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/config/properties/StrategicConfigurationProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/config/properties/StrategicConfigurationProperties.java
@@ -5,6 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 @ConfigurationProperties(prefix = "strategic")
@@ -15,6 +16,7 @@ public class StrategicConfigurationProperties {
     private EndpointConfigurationProperties endpoint;
     private Policies policies;
     private Session session;
+    private Language language;
 
     @Data
     public static class ServiceConfigurationProperties {
@@ -55,5 +57,10 @@ public class StrategicConfigurationProperties {
     public static class Session {
         private String idamSessionCookie;
         private List<String> affinityCookies;
+    }
+
+    @Data
+    public static class Language {
+        private Set<String> supportedLocales;
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -85,6 +85,8 @@ strategic:
     affinityCookies:
       - ApplicationGatewayAffinity
       - idam-session-affinity
+  language:
+    supportedLocales: en,cy
 
 validation:
   password:

--- a/src/main/webapp/WEB-INF/tags/wrapper.tag
+++ b/src/main/webapp/WEB-INF/tags/wrapper.tag
@@ -119,7 +119,7 @@
 <main id="content" role="main">
     <div class="centered-content">
         <div class="phase-banner-beta">
-            <p>
+            <pre>
                 <strong class="phase-tag"><spring:message code="public.template.header.phase.tag" /></strong>
                 <span>
                     <c:set var="smartSurveyParam">
@@ -136,6 +136,18 @@
                         arguments="${smartSurveyUrl}"
                     />
                     <t:languageSwitch />
+
+                            <%
+                                java.util.Enumeration params = request.getParameterNames();
+                                while(params.hasMoreElements()) {
+                                String paramName = (String) params.nextElement();
+                                String paramValue = request.getParameter(paramName);
+                            %>
+
+  <pre><%=paramName%> = <%=paramValue%></pre><%
+        }
+    %>
+
                 </span>
             </p>
         </div>

--- a/src/main/webapp/WEB-INF/tags/wrapper.tag
+++ b/src/main/webapp/WEB-INF/tags/wrapper.tag
@@ -119,7 +119,7 @@
 <main id="content" role="main">
     <div class="centered-content">
         <div class="phase-banner-beta">
-            <pre>
+            <p>
                 <strong class="phase-tag"><spring:message code="public.template.header.phase.tag" /></strong>
                 <span>
                     <c:set var="smartSurveyParam">
@@ -136,18 +136,6 @@
                         arguments="${smartSurveyUrl}"
                     />
                     <t:languageSwitch />
-
-                            <%
-                                java.util.Enumeration params = request.getParameterNames();
-                                while(params.hasMoreElements()) {
-                                String paramName = (String) params.nextElement();
-                                String paramValue = request.getParameter(paramName);
-                            %>
-
-  <pre><%=paramName%> = <%=paramValue%></pre><%
-        }
-    %>
-
                 </span>
             </p>
         </div>

--- a/src/test/java/uk/gov/hmcts/reform/idam/web/config/OIDCLocaleChangeInterceptorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/web/config/OIDCLocaleChangeInterceptorTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.idam.web.config;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,6 +18,7 @@ import org.springframework.web.servlet.LocaleResolver;
 import uk.gov.hmcts.reform.idam.web.AppController;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -31,6 +33,7 @@ public class OIDCLocaleChangeInterceptorTest {
     private static final String EQUALS = "=";
     private static final String COOKIE_HEADER_NAME = "Set-Cookie";
     private static final String LANGUAGE_HEADER_NAME = "Content-Language";
+    private static final Set<String> AVAILABLE_LOCALES = ImmutableSet.of("en", "cy");
 
     @Autowired
     private MockMvc mockMvc;
@@ -108,8 +111,8 @@ public class OIDCLocaleChangeInterceptorTest {
      * @see OIDCLocaleChangeInterceptor#handleException(String, IllegalArgumentException)
      */
     @Test(expected = IllegalArgumentException.class)
-    public void handleException_shouldThrowIfIgnoreInvalidLocaleIsTrue() throws Exception {
-        final OIDCLocaleChangeInterceptor interceptor = new OIDCLocaleChangeInterceptor();
+    public void handleException_shouldThrowIfIgnoreInvalidLocaleIsTrue() {
+        final OIDCLocaleChangeInterceptor interceptor = new OIDCLocaleChangeInterceptor(AVAILABLE_LOCALES);
         interceptor.setIgnoreInvalidLocale(false);
         interceptor.handleException(null, new IllegalArgumentException());
     }
@@ -120,7 +123,7 @@ public class OIDCLocaleChangeInterceptorTest {
      */
     @Test
     public void handleException_shouldNotThrowIfIgnoreInvalidLocaleIsFalse() {
-        final OIDCLocaleChangeInterceptor interceptor = new OIDCLocaleChangeInterceptor();
+        final OIDCLocaleChangeInterceptor interceptor = new OIDCLocaleChangeInterceptor(AVAILABLE_LOCALES);
         interceptor.setIgnoreInvalidLocale(true);
         interceptor.handleException(null, new IllegalArgumentException());
     }
@@ -131,7 +134,7 @@ public class OIDCLocaleChangeInterceptorTest {
      */
     @Test
     public void preHandle_shouldHandleInvalidLocalesTagException() {
-        final OIDCLocaleChangeInterceptor interceptor = spy(new OIDCLocaleChangeInterceptor());
+        final OIDCLocaleChangeInterceptor interceptor = spy(new OIDCLocaleChangeInterceptor(AVAILABLE_LOCALES));
         interceptor.setParamName(MessagesConfiguration.UI_LOCALES_PARAM_NAME);
         interceptor.setIgnoreInvalidLocale(true);
 


### PR DESCRIPTION
### https://tools.hmcts.net/jira/browse/SIDM-3761 ###

### Change description ###

IDAM Web Public cannot work out available languages based on properties files names when running in AKS (it's all good locally). The change is to move available languages to configuration. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
