### PR TITLE
fix: remove reference to idam-master tf state

### DIFF
--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -1,14 +1,3 @@
 terraform {
   backend "azurerm" {}
 }
-
-data "terraform_remote_state" "core-infra" {
-  backend = "azurerm"
-
-  config {
-    resource_group_name  = "mgmt-state-store-${var.subscription}"
-    storage_account_name = "mgmtstatestore${var.subscription}"
-    container_name       = "mgmtstatestorecontainer${var.env}"
-    key                  = "core-infra/${var.env}/terraform.tfstate"
-  }
-}


### PR DESCRIPTION
### Change description ###

Remove unused terraform data reference to the cnp-idam-master project state.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
