### PR TITLE
Update Jenkinsfile_CNP

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -188,8 +188,4 @@ withPipeline(type, product, component) {
             reportName           : "IDAM Web Public E2E functional tests result"
         ]
     }
-  
-  before('buildinfra:idam-prod') {
-      error('Stopping pipeline before Prod stages')
-  }
 }


### PR DESCRIPTION
### Change description ###

Front Door caching drops `accept` and `accept-language` headers. This fixes the default content-type for errors on idam-web-public.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

