### PR TITLE
bug(SIDM-4848): Allow to turn SSO off without conf

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/web/config/AppConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/config/AppConfiguration.java
@@ -1,78 +1,15 @@
 package uk.gov.hmcts.reform.idam.web.config;
 
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.conn.ssl.TrustStrategy;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.ssl.SSLContexts;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
-import org.springframework.web.client.RestTemplate;
-import uk.gov.hmcts.reform.idam.web.config.properties.ConfigurationProperties;
-import uk.gov.hmcts.reform.idam.web.helper.LocalePassingInterceptor;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
-import java.security.KeyManagementException;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.X509Certificate;
-import java.util.concurrent.TimeUnit;
 
 @Configuration
 @ConditionalOnMissingBean(AppConfigurationSSO.class)
 public class AppConfiguration extends WebSecurityConfigurerAdapter {
-
-    private final ConfigurationProperties configurationProperties;
-
-    public AppConfiguration(ConfigurationProperties configurationProperties) {
-        this.configurationProperties = configurationProperties;
-    }
-
-    @Bean
-    public RestTemplate getRestTemplate()
-        throws KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
-        HttpClientBuilder httpClientBuilder = HttpClients.custom()
-            .disableCookieManagement()
-            .disableAuthCaching()
-            .useSystemProperties()
-            .evictIdleConnections(configurationProperties.getServer().getMaxConnectionIdleTime(), TimeUnit.SECONDS)
-            .setMaxConnPerRoute(configurationProperties.getServer().getMaxConnectionsPerRoute())
-            .setMaxConnTotal(configurationProperties.getServer().getMaxConnectionsTotal());
-
-        if (!configurationProperties.getSsl().getVerification().getEnabled()) {
-            TrustStrategy acceptingTrustStrategy = (X509Certificate[] chain, String authType) -> true;
-            SSLContext sslContext = SSLContexts.custom()
-                .loadTrustMaterial(null, acceptingTrustStrategy)
-                .build();
-            // ignore Sonar's weak hostname verifier as we are deliberately disabling SSL verification
-            HostnameVerifier allowAllHostnameVerifier = (hostName, session) -> true; // NOSONAR
-
-            SSLConnectionSocketFactory allowAllSslSocketFactory = new SSLConnectionSocketFactory(
-                sslContext,
-                allowAllHostnameVerifier);
-
-            httpClientBuilder.setSSLSocketFactory(allowAllSslSocketFactory);
-        }
-
-        CloseableHttpClient client = httpClientBuilder.build();
-
-        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(client);
-        requestFactory.setConnectionRequestTimeout(configurationProperties.getServer().getConnectionRequestTimeout());
-        requestFactory.setConnectTimeout(configurationProperties.getServer().getConnectionTimeout());
-        requestFactory.setReadTimeout(configurationProperties.getServer().getReadTimeout());
-
-        final RestTemplate restTemplate = new RestTemplate(requestFactory);
-        restTemplate.getInterceptors().add(new LocalePassingInterceptor());
-        return restTemplate;
-    }
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -91,4 +28,5 @@ public class AppConfiguration extends WebSecurityConfigurerAdapter {
                 .anyRequest().permitAll();
         // @formatter:on
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/config/AppConfigurationSSO.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/config/AppConfigurationSSO.java
@@ -1,16 +1,9 @@
 package uk.gov.hmcts.reform.idam.web.config;
 
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.conn.ssl.TrustStrategy;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.ssl.SSLContexts;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -23,21 +16,11 @@ import org.springframework.security.oauth2.jwt.JwtDecoders;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
-import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.reform.idam.web.client.OidcApi;
 import uk.gov.hmcts.reform.idam.web.client.SsoFederationApi;
 import uk.gov.hmcts.reform.idam.web.config.properties.ConfigurationProperties;
 import uk.gov.hmcts.reform.idam.web.helper.AuthHelper;
-import uk.gov.hmcts.reform.idam.web.helper.LocalePassingInterceptor;
 import uk.gov.hmcts.reform.idam.web.sso.SSOAuthenticationSuccessHandler;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
-import java.security.KeyManagementException;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.X509Certificate;
-import java.util.concurrent.TimeUnit;
 
 @Configuration
 @ConditionalOnProperty("features.federated-s-s-o")
@@ -64,44 +47,6 @@ public class AppConfigurationSSO extends WebSecurityConfigurerAdapter {
         this.ssoFederationApi = ssoFederationApi;
         this.oidcApi = oidcApi;
         this.authHelper = authHelper;
-    }
-
-    @Bean
-    public RestTemplate getRestTemplate()
-        throws KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
-        HttpClientBuilder httpClientBuilder = HttpClients.custom()
-            .disableCookieManagement()
-            .disableAuthCaching()
-            .useSystemProperties()
-            .evictIdleConnections(configurationProperties.getServer().getMaxConnectionIdleTime(), TimeUnit.SECONDS)
-            .setMaxConnPerRoute(configurationProperties.getServer().getMaxConnectionsPerRoute())
-            .setMaxConnTotal(configurationProperties.getServer().getMaxConnectionsTotal());
-
-        if (!configurationProperties.getSsl().getVerification().getEnabled()) {
-            TrustStrategy acceptingTrustStrategy = (X509Certificate[] chain, String authType) -> true;
-            SSLContext sslContext = SSLContexts.custom()
-                .loadTrustMaterial(null, acceptingTrustStrategy)
-                .build();
-            // ignore Sonar's weak hostname verifier as we are deliberately disabling SSL verification
-            HostnameVerifier allowAllHostnameVerifier = (hostName, session) -> true; // NOSONAR
-
-            SSLConnectionSocketFactory allowAllSslSocketFactory = new SSLConnectionSocketFactory(
-                sslContext,
-                allowAllHostnameVerifier);
-
-            httpClientBuilder.setSSLSocketFactory(allowAllSslSocketFactory);
-        }
-
-        CloseableHttpClient client = httpClientBuilder.build();
-
-        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(client);
-        requestFactory.setConnectionRequestTimeout(configurationProperties.getServer().getConnectionRequestTimeout());
-        requestFactory.setConnectTimeout(configurationProperties.getServer().getConnectionTimeout());
-        requestFactory.setReadTimeout(configurationProperties.getServer().getReadTimeout());
-
-        final RestTemplate restTemplate = new RestTemplate(requestFactory);
-        restTemplate.getInterceptors().add(new LocalePassingInterceptor());
-        return restTemplate;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/config/AppConfigurationSSO.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/config/AppConfigurationSSO.java
@@ -6,17 +6,30 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContexts;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoders;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.reform.idam.web.client.OidcApi;
+import uk.gov.hmcts.reform.idam.web.client.SsoFederationApi;
 import uk.gov.hmcts.reform.idam.web.config.properties.ConfigurationProperties;
+import uk.gov.hmcts.reform.idam.web.helper.AuthHelper;
 import uk.gov.hmcts.reform.idam.web.helper.LocalePassingInterceptor;
+import uk.gov.hmcts.reform.idam.web.sso.SSOAuthenticationSuccessHandler;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -27,13 +40,30 @@ import java.security.cert.X509Certificate;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
-@ConditionalOnMissingBean(AppConfigurationSSO.class)
-public class AppConfiguration extends WebSecurityConfigurerAdapter {
+@ConditionalOnProperty("features.federated-s-s-o")
+public class AppConfigurationSSO extends WebSecurityConfigurerAdapter {
 
     private final ConfigurationProperties configurationProperties;
 
-    public AppConfiguration(ConfigurationProperties configurationProperties) {
+    private final OAuth2AuthorizedClientRepository repository;
+
+    private final SsoFederationApi ssoFederationApi;
+
+    private final OidcApi oidcApi;
+
+    private final AuthHelper authHelper;
+
+    @Value("${spring.security.oauth2.client.provider.oidc.issuer-uri}")
+    private String issuerUri;
+
+    public AppConfigurationSSO(ConfigurationProperties configurationProperties,
+                            OAuth2AuthorizedClientRepository repository,
+                            SsoFederationApi ssoFederationApi, OidcApi oidcApi, AuthHelper authHelper) {
         this.configurationProperties = configurationProperties;
+        this.repository = repository;
+        this.ssoFederationApi = ssoFederationApi;
+        this.oidcApi = oidcApi;
+        this.authHelper = authHelper;
     }
 
     @Bean
@@ -79,16 +109,43 @@ public class AppConfiguration extends WebSecurityConfigurerAdapter {
         // @formatter:off
         http
             .csrf()
-                .ignoringAntMatchers("/o/**")
+            .ignoringAntMatchers("/o/**")
             .csrfTokenRepository(new CookieCsrfTokenRepository()).and()
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
             .authorizeRequests()
-                .antMatchers("/o/**").permitAll()
-                .antMatchers("/resources/**").permitAll()
-                .antMatchers("/assets/**").permitAll()
-                .antMatchers("/users/register").permitAll()
-                .antMatchers("/users/activate").permitAll()
-                .anyRequest().permitAll();
+            .antMatchers("/o/**").permitAll()
+            .antMatchers("/resources/**").permitAll()
+            .antMatchers("/assets/**").permitAll()
+            .antMatchers("/users/register").permitAll()
+            .antMatchers("/users/activate").permitAll()
+            .anyRequest().permitAll()
+            .and()
+            .oauth2Login()
+            // non existent page otherwise defaults to /login
+            .loginPage("/sso/login.html")
+            .failureUrl("/error")
+            .successHandler(myAuthenticationSuccessHandler(repository))
+            .and()
+            .oauth2Client();
         // @formatter:on
+    }
+
+    @Bean
+    public AuthenticationSuccessHandler myAuthenticationSuccessHandler(OAuth2AuthorizedClientRepository repository){
+        return new SSOAuthenticationSuccessHandler(repository, ssoFederationApi, oidcApi,
+            configurationProperties.getStrategic().getSession(), authHelper);
+    }
+
+    /*
+     * If in future we have multiple providers this needs to be replaced with spring security 5s
+     * JwtIssuerAuthenticationManagerResolver which supports multiple issuers
+     */
+    @Bean
+    JwtDecoder jwtDecoder() {
+        NimbusJwtDecoder jwtDecoder = (NimbusJwtDecoder) JwtDecoders.fromOidcIssuerLocation(issuerUri);
+        OAuth2TokenValidator<Jwt> withAudience = new DelegatingOAuth2TokenValidator<>();
+        jwtDecoder.setJwtValidator(withAudience);
+
+        return jwtDecoder;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/config/RestTemplateConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/config/RestTemplateConfiguration.java
@@ -1,0 +1,71 @@
+package uk.gov.hmcts.reform.idam.web.config;
+
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContexts;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.reform.idam.web.config.properties.ConfigurationProperties;
+import uk.gov.hmcts.reform.idam.web.helper.LocalePassingInterceptor;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class RestTemplateConfiguration {
+
+    private final ConfigurationProperties configurationProperties;
+
+    public RestTemplateConfiguration(ConfigurationProperties configurationProperties) {
+        this.configurationProperties = configurationProperties;
+    }
+
+    @Bean
+    public RestTemplate getRestTemplate()
+        throws KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
+        HttpClientBuilder httpClientBuilder = HttpClients.custom()
+            .disableCookieManagement()
+            .disableAuthCaching()
+            .useSystemProperties()
+            .evictIdleConnections(configurationProperties.getServer().getMaxConnectionIdleTime(), TimeUnit.SECONDS)
+            .setMaxConnPerRoute(configurationProperties.getServer().getMaxConnectionsPerRoute())
+            .setMaxConnTotal(configurationProperties.getServer().getMaxConnectionsTotal());
+
+        if (!configurationProperties.getSsl().getVerification().getEnabled()) {
+            TrustStrategy acceptingTrustStrategy = (X509Certificate[] chain, String authType) -> true;
+            SSLContext sslContext = SSLContexts.custom()
+                .loadTrustMaterial(null, acceptingTrustStrategy)
+                .build();
+            // ignore Sonar's weak hostname verifier as we are deliberately disabling SSL verification
+            HostnameVerifier allowAllHostnameVerifier = (hostName, session) -> true; // NOSONAR
+
+            SSLConnectionSocketFactory allowAllSslSocketFactory = new SSLConnectionSocketFactory(
+                sslContext,
+                allowAllHostnameVerifier);
+
+            httpClientBuilder.setSSLSocketFactory(allowAllSslSocketFactory);
+        }
+
+        CloseableHttpClient client = httpClientBuilder.build();
+
+        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(client);
+        requestFactory.setConnectionRequestTimeout(configurationProperties.getServer().getConnectionRequestTimeout());
+        requestFactory.setConnectTimeout(configurationProperties.getServer().getConnectionTimeout());
+        requestFactory.setReadTimeout(configurationProperties.getServer().getReadTimeout());
+
+        final RestTemplate restTemplate = new RestTemplate(requestFactory);
+        restTemplate.getInterceptors().add(new LocalePassingInterceptor());
+        return restTemplate;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/sso/SSOAuthenticationSuccessHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/sso/SSOAuthenticationSuccessHandler.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.idam.web.sso;
 import feign.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
@@ -34,6 +35,7 @@ import static org.springframework.http.HttpHeaders.SET_COOKIE;
 import static uk.gov.hmcts.reform.idam.web.helper.ErrorHelper.restException;
 
 @Slf4j
+@ConditionalOnProperty("features.federated-s-s-o")
 public class SSOAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
 
     private final RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-4848


### Change description ###
Update how we load oauth spring filters to allow us to turn it off and having the conf empty

### HOW ARE WE TESTING THIS ###
First I'll get this PR green to "prove" that it won't fail tests when SSO is ON

Then we'll force merge a PR with SSO OFF, tests will show failing SSO tests

Shrav will test it
Then we'll revert back to normal

Then Shrav will test it again?


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
