### PR TITLE
Another fix for SSO from XUI

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/web/sso/SSOAuthenticationSuccessHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/sso/SSOAuthenticationSuccessHandler.java
@@ -148,6 +148,8 @@ public class SSOAuthenticationSuccessHandler implements AuthenticationSuccessHan
         );
 
         params.remove("login_hint");
+        // ignore prompt as we don't want a federated user that is successfully authenticated to land on the login page
+        params.remove("prompt");
 
         Response response = oidcApi.oauth2AuthorizePost(
             StringUtils.join(cookies, ";"),


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-4955


### Change description ###
Ignore prompt param when going through the SSO login flow as we don't want a federated user that is already authentcated (by definition) to land on our login page.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
