### PR TITLE
Do not (yet) force all ejudiciary users to go through SSO 

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -126,4 +126,6 @@ features:
   federated-s-s-o: ${federated.sso:true}
 
 ssoEmailDomains:
-  ejudiciary.net: ejudiciary-aad
+  dummy: dummy
+# re-enable only when SSO feature is enabled for everyone
+#  ejudiciary.net: ejudiciary-aad


### PR DESCRIPTION
# JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-4811


### Change description ###
While the SSO feature is running its pilot, we don't want all ejudiciary.net accounts to be forced to go through SSO login. Once the feature can be enabled for everyone, then we can re-enable the relevant configuration.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
