### PR TITLE
SIDM-5201: Remove the OTP duration info from the Verification code screen copy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,13 +110,17 @@ allprojects {
     implementation group: 'org.pitest', name: 'pitest', version: '1.4.6'
     implementation group: 'info.solidsoft.gradle.pitest', name: 'gradle-pitest-plugin', version: '1.4.6'
     implementation group: 'org.owasp.encoder', name: 'encoder-jsp', version: '1.2.2'
-    implementation group: 'org.codehaus.sonar-plugins', name: 'sonar-pitest-plugin', version: '0.5'
+    implementation (group: 'org.codehaus.sonar-plugins', name: 'sonar-pitest-plugin', version: '0.5') {
+      exclude module: 'junit'
+    }
     implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.0.4'
     implementation group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version: '0.0.4'
 
     testCompileOnly("org.projectlombok:lombok")
     testAnnotationProcessor("org.projectlombok:lombok")
-    testCompile('pl.pragmatists:JUnitParams:1.1.1')
+    testCompile('pl.pragmatists:JUnitParams:1.1.1') {
+      exclude(module: 'junit')
+    }
 
     testImplementation group: 'org.mockito', name: 'mockito-core'
     testImplementation group: 'org.springframework', name: 'spring-test'
@@ -125,6 +129,7 @@ allprojects {
       exclude(module: 'commons-logging')
     }
     testImplementation group: 'org.springframework.security', name: 'spring-security-test'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
   }
 
   tasks.withType(JavaCompile) {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -163,7 +163,7 @@ public.login.error.verification.field.code.length=Enter a valid verification cod
 
 #One Time Password Verification
 public.verification.subheading.verification.required=Verification required
-public.verification.p=To complete login, a one-time verification code has been sent to your email address. This is valid for 5 minutes.
+public.verification.p=To complete login, a one-time verification code has been sent to your email address.
 public.verification.code.label=Enter verification code
 public.verification.form.submit=Submit
 

--- a/src/main/resources/messages_cy.properties
+++ b/src/main/resources/messages_cy.properties
@@ -164,7 +164,7 @@ public.login.error.verification.field.code.length=Rhowch god dilysu dilys
 
 #One Time Password Verification
 public.verification.subheading.verification.required=Mae angen dilysu eich cyfrif
-public.verification.p=I gwblhau'r broses fewngofnodi, mae cod dilysu y bydd rhaid ichi ei ddefnyddio unwaith wedi’i anfon i'ch cyfeiriad e-bost. Mae’n ddilys am 5 munud.
+public.verification.p=I gwblhau'r broses fewngofnodi, mae cod dilysu y bydd rhaid ichi ei ddefnyddio unwaith wedi’i anfon i'ch cyfeiriad e-bost.
 public.verification.code.label=Rhowch god dilysu
 public.verification.form.submit=Cyflwyno
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-5201


### Change description ###
Changed en/cy messages for verification code screen to not include duration information.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
