### PR TITLE
Sidm 5177 already active

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/web/UserController.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/UserController.java
@@ -251,6 +251,7 @@ public class UserController {
      * @should return useractivation view and invalid passowrd error in model if HttpClientErrorException occurs and http status is 400 and password is not blacklisted
      * @should return expiredtoken view if HttpClientErrorException occurs and http status is 400 and token is invalid
      * @should return redirect expiredtoken page if selfRegisterUser service throws HttpClientErrorException and Http code is 404
+     * @should return redirect to error page with already activated error if validate password returns conflict
      */
     @PostMapping("/activate")
     public ModelAndView activateUser(@RequestParam("token") String token, @RequestParam("code") String code,
@@ -278,6 +279,11 @@ public class UserController {
             if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
                 // don't expose the token in the error page
                 return new ModelAndView("redirect:expiredtoken", (Map<String, ?>) null);
+            } else if (e.getStatusCode() == HttpStatus.CONFLICT) {
+                log.error("An error occurred validating user activation token in activate: {}", token);
+                log.error("Response body: {}", e.getResponseBodyAsString(), e);
+                model.put(ERROR_MSG, ALREADY_ACTIVATED_KEY);
+                return new ModelAndView(ERRORPAGE_VIEW, model);
             }
 
             if (e.getStatusCode() == HttpStatus.BAD_REQUEST) {

--- a/src/main/webapp/WEB-INF/jsp/useractivation.jsp
+++ b/src/main/webapp/WEB-INF/jsp/useractivation.jsp
@@ -56,8 +56,8 @@
                 <input class="form-control ${hasPassword2Error ? "form-control-error" : ""}" type="password" id="password2" name="password2" value="${fn:escapeXml(password2)}" autocomplete="off">
             </div>
 
-            <input class="button" type="submit" value="<spring:message code="public.common.button.continue.text"/>" id="activate">
-
+            <input class="button" type="submit" value="<spring:message code="public.common.button.continue.text"/>" id="activate"
+                onclick="setTimeout(function () {document.getElementById('activate').disabled = true;document.getElementById('activate').style.opacity='0.5';}, 0);">
             <input type="hidden" id="token" name="token" value="${fn:escapeXml(token)}">
             <input type="hidden" id="code" name="code" value="${fn:escapeXml(code)}">
         </form:form>

--- a/src/test/java/uk/gov/hmcts/reform/idam/web/UserControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/web/UserControllerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.idam.web;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
@@ -368,6 +369,24 @@ public class UserControllerTest {
     }
 
     /**
+     * @verifies return redirect to error page with already activated error if validate password returns conflict
+     * @see UserController#activateUser(String, String, String, String, Map)
+     */
+    @Test
+    public void activateUser_shouldReturnRedirectToErrorPageWithAlreadyActivatedErrorIfValidatePasswordReturnsConflict() throws Exception {
+        ActivationResult activationResult = new ActivationResult();
+        activationResult.setRedirectUri(REDIRECT_URI);
+        activationResult.setStaleUserActivated(true);
+
+        given(validationService.validatePassword(eq(USER_PASSWORD), eq(USER_PASSWORD), any(Map.class))).willThrow(new HttpClientErrorException(HttpStatus.CONFLICT, "Conflict", null, null));
+
+        mockMvc.perform(getActivateUserPostRequest(USER_ACTIVATION_TOKEN, USER_ACTIVATION_CODE, USER_PASSWORD, USER_PASSWORD))
+            .andExpect(status().isOk())
+            .andExpect(model().attribute(ERROR_MSG, ALREADY_ACTIVATED_KEY))
+            .andExpect(view().name(ERROR_VIEW_NAME));
+    }
+
+    /**
      * @verifies return users view
      * @see UserController#users(Map)
      */
@@ -552,4 +571,5 @@ public class UserControllerTest {
             .andExpect(model().attribute(REDIRECTURI, REDIRECTURI))
             .andExpect(view().name(RESET_PASSWORD_SUCCESS_VIEW));
     }
+
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-5177

### Change description ###

The API can return a conflict response for activate user if the user has already been created. The easiest way to test this is to open a valid "register" link in two tabs, complete the process in one and then attempt to save the same password in the second. Before this change the error would have been displayed as an invalid password being entered. Now the message "Account already activated" is displayed.

The use of setTimeout is from here:
https://chasingcode.dev/blog/javascript-disable-submit-button-form/

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
