### PR TITLE
SIDM-5175: Aligning the Verification code screen to the UX prototype

### DIFF
--- a/src/main/resources/messages_cy.properties
+++ b/src/main/resources/messages_cy.properties
@@ -167,7 +167,7 @@ public.login.error.verification.expired.code.instruction.2=Bydd rhaid i chi gych
 #One Time Password Verification
 public.verification.subheading.verification.required=Mae angen dilysu eich cyfrif
 public.verification.p=Rydym wedi anfon cod 8 digid atoch trwy e-bost.
-public.verification.check.inbox.instruction=Mewn rhai achosion, gall yr e-bost gymryd hyd at 30 munud i gyrraedd. Gwiriwch eich mewnflwch yn rheolaidd, gan gynnwys eich ffolder spam.
+public.verification.check.inbox.instruction=Mewn rhai achosion, gall gymryd hyd at 30 munud i’r neges e-bost gyrraedd. Gwiriwch eich mewnflwch yn rheolaidd, gan gynnwys eich ffolder spam.
 public.verification.code.label=Nodwch y cod
 public.verification.form.submit=Cyflwyno
 

--- a/src/main/webapp/WEB-INF/jsp/verification.jsp
+++ b/src/main/webapp/WEB-INF/jsp/verification.jsp
@@ -94,40 +94,42 @@
 
             <h1 class="heading-large"><spring:message code="public.verification.subheading.verification.required"/></h1>
             <div class="form-section">
-                <p><spring:message code="public.verification.p"/></p>
-                <p><spring:message code="public.verification.check.inbox.instruction"/></p>
-                <div class="form-group ${hasBindError? 'form-group-error' : ''}">
-                    <label for="code">
-                        <span class="form-label">
-                            <spring:message code="public.verification.code.label"/>
-                        </span>
-                    </label>
-                    <c:if test="${hasBindError}">
-                        <span class="error-message">
-                            <c:choose>
-                                <c:when test="${hasOtpSessionExpired}">
-                                    <c:url value="/login" var="loginUrl">
-                                        <c:param name="redirect_uri" value="${redirect_uri}"/>
-                                        <c:param name="client_id" value="${client_id}"/>
-                                        <c:param name="state" value="${state}"/>
-                                        <c:param name="nonce" value="${nonce}"/>
-                                        <c:param name="prompt" value="${prompt}"/>
-                                        <c:param name="scope" value="${scope}"/>
-                                        <c:param name="response_type" value="${response_type}"/>
-                                    </c:url>
-                                    <spring:message code="public.login.error.verification.field.code.expired" htmlEscape="false" arguments="${loginUrl}"/>
-                                </c:when>
-                                <c:otherwise>
-                                    <spring:message code="public.login.error.verification.field.code.incorrect"/>
-                                </c:otherwise>
-                            </c:choose>
-                        </span>
-                    </c:if>
-                    <form:input
-                        class="form-control${hasBindError? ' form-control-error' : ''}"
-                        id="code" name="code" path="code" type="code" value="" autocomplete="off"/>
+                <div class="column-two-thirds" style="padding: 0;">
+                    <p><spring:message code="public.verification.p"/></p>
+                    <p><spring:message code="public.verification.check.inbox.instruction"/></p>
+                    <div class="form-group ${hasBindError? 'form-group-error' : ''}">
+                        <label for="code">
+                            <span class="form-label">
+                                <spring:message code="public.verification.code.label"/>
+                            </span>
+                        </label>
+                        <c:if test="${hasBindError}">
+                            <span class="error-message">
+                                <c:choose>
+                                    <c:when test="${hasOtpSessionExpired}">
+                                        <c:url value="/login" var="loginUrl">
+                                            <c:param name="redirect_uri" value="${redirect_uri}"/>
+                                            <c:param name="client_id" value="${client_id}"/>
+                                            <c:param name="state" value="${state}"/>
+                                            <c:param name="nonce" value="${nonce}"/>
+                                            <c:param name="prompt" value="${prompt}"/>
+                                            <c:param name="scope" value="${scope}"/>
+                                            <c:param name="response_type" value="${response_type}"/>
+                                        </c:url>
+                                        <spring:message code="public.login.error.verification.field.code.expired" htmlEscape="false" arguments="${loginUrl}"/>
+                                    </c:when>
+                                    <c:otherwise>
+                                        <spring:message code="public.login.error.verification.field.code.incorrect"/>
+                                    </c:otherwise>
+                                </c:choose>
+                            </span>
+                        </c:if>
+                        <form:input
+                            class="form-control${hasBindError? ' form-control-error' : ''}"
+                            id="code" name="code" path="code" type="text" style="width:120px" value="" autocomplete="off"/>
+                    </div>
+                    <input class="button" type="submit" value="<spring:message code="public.verification.form.submit" />">
                 </div>
-                <input class="button" type="submit" value="<spring:message code="public.verification.form.submit" />">
             </div>
         </form:form>
     </article>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-5175


### Change description ###
* Make the code input shorter (fixed width, per prototype)
* Make the text paragraph take up 2/3 of the screen estate (on normal screens)
* Added Welsh translation as provided by the Welsh Team



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
