### PR TITLE
suppress CVE errors

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -375,4 +375,23 @@
         <gav regex="true">^org\.apache\.tomcat\.embed:tomcat-embed-.+:9\.0\..*$</gav>
         <cve>CVE-2020-13943</cve>
     </suppress>
+
+    <!-- This vulnerability can only be exploited from the local network -->
+    <suppress>
+        <gav regex="true">^org\.owasp\.encoder:encoder-jsp:.*$</gav>
+        <cve>CVE-2020-29242</cve>
+        <cve>CVE-2020-29243</cve>
+        <cve>CVE-2020-29244</cve>
+        <cve>CVE-2020-29245</cve>
+    </suppress>
+
+    <!-- This vulnerability can only be exploited from the local network -->
+    <suppress>
+        <gav regex="true">^com\.nimbusds:lang-tag:.*$</gav>
+        <cve>CVE-2020-29242</cve>
+        <cve>CVE-2020-29243</cve>
+        <cve>CVE-2020-29244</cve>
+        <cve>CVE-2020-29245</cve>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
### Change description ###

CVE-2020-29243
	https://nvd.nist.gov/vuln/detail/CVE-2020-29243
	https://vuldb.com/?id.166877
	The attack needs to be initiated within the local network.
CVE-2020-29242 
	https://nvd.nist.gov/vuln/detail/CVE-2020-29242
	https://vuldb.com/?id.166876
	The attack needs to be done within the local network
CVE-2020-29245
	https://nvd.nist.gov/vuln/detail/CVE-2020-29245
	https://vuldb.com/?id.166879
	Access to the local network is required for this attack to succeed
CVE-2020-29244
	https://nvd.nist.gov/vuln/detail/CVE-2020-29244
	https://vuldb.com/?id.166878
	Access to the local network is required for this attack

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
