### PR TITLE
upgrade netflix servo only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ allprojects {
       exclude(module: 'rxnetty-servo')
       exclude(module: 'rxnetty')
     }
+    implementation group: 'com.netflix.servo', name: 'servo-core', version: '0.13.0'
     implementation group: 'org.springframework.security', name: 'spring-security-taglibs'
 
     compileOnly("org.projectlombok:lombok")


### PR DESCRIPTION
### JIRA ###

https://tools.hmcts.net/jira/browse/SIDM-5323

### Change description ###

Resolve CVE-2020-27534 by upgrading netflix.servo dependency

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
