### PR TITLE
upgrade netty

### DIFF
--- a/audit.json
+++ b/audit.json
@@ -78,6 +78,7 @@
   "10095_Backup File Disclosure_https://idam-web-public.aat.platform.hmcts.net/ruxitagentjs_ICA2SVfjqrux_10185200212095618.log_GET": "ignore",
   "10095_Backup File Disclosure_https://idam-web-public.aat.platform.hmcts.net/terms-and-conditions.log_GET": "ignore",
   "10096_Timestamp Disclosure - Unix_https://-web-public.aat.platform.hmcts.net/contact-us_GET": "ignore",
+  "10096_Timestamp Disclosure - Unix_https://idam-web-public.aat.platform.hmcts.net_GET":"ignore",
   "10096_Timestamp Disclosure - Unix_https://idam-web-public.aat.platform.hmcts.net/_GET":"ignore",
   "10096_Timestamp Disclosure - Unix_https://idam-web-public.aat.platform.hmcts.net/contact-us_GET": "ignore",
   "10096_Timestamp Disclosure - Unix_https://idam-web-public.aat.platform.hmcts.net/cookies_GET": "ignore",

--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,12 @@ allprojects {
     }
     implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.0.4'
     implementation group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version: '0.0.4'
+    implementation group: 'io.netty', name: 'netty-handler', version: '4.1.59.Final'
+    implementation group: 'io.netty', name: 'netty-transport', version: '4.1.59.Final'
+    implementation group: 'io.netty', name: 'netty-common', version: '4.1.59.Final'
+    implementation group: 'io.netty', name: 'netty-codec', version: '4.1.59.Final'
+    implementation group: 'io.netty', name: 'netty-resolver', version: '4.1.59.Final'
+    implementation group: 'io.netty', name: 'netty-buffer', version: '4.1.59.Final'
 
     testCompileOnly("org.projectlombok:lombok")
     testAnnotationProcessor("org.projectlombok:lombok")

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ allprojects {
   ext['spring.boot.version'] = '2.2.12.RELEASE'
   ext['jackson.version'] = '2.12.0'
   ext['guava.version'] = '30.0-jre'
+  ext['netty.version'] = '4.1.59.Final'
 
   dependencyManagement {
     imports {
@@ -116,12 +117,6 @@ allprojects {
     }
     implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.0.4'
     implementation group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version: '0.0.4'
-    implementation group: 'io.netty', name: 'netty-handler', version: '4.1.59.Final'
-    implementation group: 'io.netty', name: 'netty-transport', version: '4.1.59.Final'
-    implementation group: 'io.netty', name: 'netty-common', version: '4.1.59.Final'
-    implementation group: 'io.netty', name: 'netty-codec', version: '4.1.59.Final'
-    implementation group: 'io.netty', name: 'netty-resolver', version: '4.1.59.Final'
-    implementation group: 'io.netty', name: 'netty-buffer', version: '4.1.59.Final'
 
     testCompileOnly("org.projectlombok:lombok")
     testAnnotationProcessor("org.projectlombok:lombok")

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,6 @@ allprojects {
   ext['spring.boot.version'] = '2.2.12.RELEASE'
   ext['jackson.version'] = '2.12.0'
   ext['guava.version'] = '30.0-jre'
-  ext['netty.version'] = '4.1.59.Final'
 
   dependencyManagement {
     imports {
@@ -117,6 +116,12 @@ allprojects {
     }
     implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.0.4'
     implementation group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version: '0.0.4'
+    implementation group: 'io.netty', name: 'netty-handler', version: '4.1.59.Final'
+    implementation group: 'io.netty', name: 'netty-transport', version: '4.1.59.Final'
+    implementation group: 'io.netty', name: 'netty-common', version: '4.1.59.Final'
+    implementation group: 'io.netty', name: 'netty-codec', version: '4.1.59.Final'
+    implementation group: 'io.netty', name: 'netty-resolver', version: '4.1.59.Final'
+    implementation group: 'io.netty', name: 'netty-buffer', version: '4.1.59.Final'
 
     testCompileOnly("org.projectlombok:lombok")
     testAnnotationProcessor("org.projectlombok:lombok")


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-5498

### Change description ###

Fix CVE-2021-21290 by upgrading netty (a dependency of spring) from 4.1.55 to 4.1.59

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
