### PR TITLE
SIDM-5622: Upgrade netty to address CVE-2021-21295

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ allprojects {
   ext['spring.boot.version'] = '2.2.12.RELEASE'
   ext['jackson.version'] = '2.12.0'
   ext['guava.version'] = '30.0-jre'
-  ext['netty.version'] = '4.1.59.Final'
+  ext['netty.version'] = '4.1.60.Final'
   ext['spring-security.version'] = '5.2.9.RELEASE'
 
   dependencyManagement {

--- a/charts/idam-web-public/values.preview.template.yaml
+++ b/charts/idam-web-public/values.preview.template.yaml
@@ -6,4 +6,4 @@ java:
   ingressIP: ${INGRESS_IP}
   consulIP: ${CONSUL_LB_IP}
   environment:
-    STRATEGIC_SERVICE_URL: http://idam-api-java
+    STRATEGIC_SERVICE_URL: http://idam-api


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-5622


### Change description ###
Upgraded `netty.version` to latest minor change that mitigates CVE-2021-21295. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
