### PR TITLE
SIDM-6045: Upgrade json-smart to resolve CVE-2021-27568

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ allprojects {
   def idamBomVersion = '2.6.2'
   ext['spring.boot.version'] = '2.4.6'
   ext['netty.version'] = '4.1.63.Final'
+  ext['json-smart.version'] = '2.3.1'
 
   configurations.all {
     exclude group: "org.glassfish", module: "jakarta.el"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-6045


### Change description ###
Upgrade json-smart to 2.3.1.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
