### PR TITLE
SIDM-6126 get test urls for org-mfa from vault

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -21,6 +21,8 @@ def secrets = [
         secret('smoke-test-user-username', 'SMOKE_TEST_USER_USERNAME'),
         secret('smoke-test-user-password', 'SMOKE_TEST_USER_PASSWORD'),
         secret('notify-api-key', 'NOTIFY_API_KEY'),
+        secret('test-rpe-auth-url', 'RPE_AUTH_URL'),
+        secret('test-ref-data-url', 'REF_DATA_URL '),
         secret('EJUDICIARY-TEST-USER-PASSWORD', 'EJUDICIARY_TEST_USER_PASSWORD')
     ]
 ]

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -23,6 +23,8 @@ def secrets = [
         secret('smoke-test-user-username', 'SMOKE_TEST_USER_USERNAME'),
         secret('smoke-test-user-password', 'SMOKE_TEST_USER_PASSWORD'),
         secret('notify-api-key', 'NOTIFY_API_KEY'),
+        secret('test-rpe-auth-url', 'RPE_AUTH_URL'),
+        secret('test-ref-data-url', 'REF_DATA_URL '),
         secret('EJUDICIARY-TEST-USER-PASSWORD', 'EJUDICIARY_TEST_USER_PASSWORD')
     ]
 ]

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -9,7 +9,9 @@ def secrets = [
     'idam-idam-${env}': [
         secret('smoke-test-user-username', 'SMOKE_TEST_USER_USERNAME'),
         secret('smoke-test-user-password', 'SMOKE_TEST_USER_PASSWORD'),
-        secret('notify-api-key', 'NOTIFY_API_KEY')
+        secret('notify-api-key', 'NOTIFY_API_KEY'),
+        secret('test-rpe-auth-url', 'RPE_AUTH_URL'),
+        secret('test-ref-data-url', 'REF_DATA_URL ')
     ]
 ]
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-6126

### Change description ###

Get RPE and Ref Data urls for org/mfa testing from vaults

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
