### PR TITLE
SIDM-6048: Fix for adding fortify scan stage to nightly master pipeline

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -4,7 +4,7 @@ properties([
     pipelineTriggers([cron('30 02 * * *')]),
 
     parameters([
-
+        string(name: 'ENVIRONMENT', defaultValue: 'aat', description: 'Environment to test'),
         string(name: 'URL_TO_TEST', defaultValue: 'https://idam-web-public.aat.platform.hmcts.net', description: 'The URL you want to run these tests against'),
         string(name: 'API_URL_TO_TEST', defaultValue: 'https://idam-api.aat.platform.hmcts.net', description: 'The API URL you want to run these tests against '),
     ])


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-6048


### Change description ###
Add `ENVIRONMENT` parameter to the Nightly jenkins pipeline and default to `aat`.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
