### PR TITLE
SIDM-6295 ignore "prompt=login" during login/verification calls to api/AM

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/web/AppController.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/AppController.java
@@ -438,7 +438,7 @@ public class AppController {
 
                     return new ModelAndView("redirect:/" + VERIFICATION_VIEW, authorizeParams);
                 } else {
-                    final String responseUrl = authoriseUser(cookies, httpRequest);
+                    final String responseUrl = authoriseUserDuringLogin(cookies, httpRequest);
                     final boolean loginSuccess = responseUrl != null && !responseUrl.contains("error");
 
                     if (loginSuccess) {
@@ -493,12 +493,12 @@ public class AppController {
         return new ModelAndView(LOGIN_VIEW, model.asMap());
     }
 
-    private String authoriseUser(List<String> cookies, HttpServletRequest httpRequest) {
+    private String authoriseUserDuringLogin(List<String> cookies, HttpServletRequest httpRequest) {
         String responseUrl = null;
         if (cookies != null) {
             Map<String, String> params = new HashMap<>();
             httpRequest.getParameterMap().forEach((key, values) -> {
-                    if (values.length > 0 && !String.join(" ", values).trim().isEmpty())
+                    if (values.length > 0 && !String.join(" ", values).trim().isEmpty() && !key.equals("prompt"))
                         params.put(key, String.join(" ", values));
                 }
             );
@@ -599,7 +599,7 @@ public class AppController {
             final List<String> responseCookies = spiService.submitOtpeAuthentication(authId, ipAddress, request.getCode());
             log.info("/verification: Successful OTP submission request");
 
-            final String responseUrl = authoriseUser(responseCookies, httpRequest);
+            final String responseUrl = authoriseUserDuringLogin(responseCookies, httpRequest);
             final boolean loginSuccess = responseUrl != null && !responseUrl.contains("error");
             if (loginSuccess) {
                 log.info("/verification: Successful login");

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/AppController.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/AppController.java
@@ -355,6 +355,7 @@ public class AppController {
 
     /**
      * @should put in model correct data then call authorize service and redirect using redirect url returned by service
+     * @should put in model correct data then call authorize service and redirect using redirect url returned by service that does not match redirect
      * @should put in model correct data if username or password are empty.
      * @should put in model the correct data and return login view if authorize service doesn't return a response url
      * @should put in model the correct error detail in case authorize service throws a HttpClientErrorException and status code is 403 then return login view
@@ -438,16 +439,20 @@ public class AppController {
 
                     return new ModelAndView("redirect:/" + VERIFICATION_VIEW, authorizeParams);
                 } else {
-                    final String responseUrl = authoriseUserDuringLogin(cookies, httpRequest);
+                    final String responseUrl = authoriseUserAfterAuthentication(cookies, httpRequest);
                     final boolean loginSuccess = responseUrl != null && !responseUrl.contains("error");
 
                     if (loginSuccess) {
-                        log.info("/login: Successful login - {}", obfuscateEmailAddress(request.getUsername()));
+                        if (responseUrl.startsWith(redirectUri)) {
+                            log.info("/login: Successful login - {}", obfuscateEmailAddress(request.getUsername()));
+                        } else {
+                            log.info("/login: Successful for user {} with unexpected redirect {}", obfuscateEmailAddress(request.getUsername()), responseUrl);
+                        }
                         List<String> secureCookies = authHelper.makeCookiesSecure(cookies);
                         secureCookies.forEach(cookie -> response.addHeader(HttpHeaders.SET_COOKIE, cookie));
                         return new ModelAndView(REDIRECT_PREFIX + responseUrl);
                     } else {
-                        log.info("/login: There is a problem while logging in  user - {}", obfuscateEmailAddress(request.getUsername()));
+                        log.info("/login: There is a problem while logging in  user {}, response url is {}", obfuscateEmailAddress(request.getUsername()), responseUrl != null ? responseUrl : "n/a");
                         model.addAttribute(HAS_LOGIN_FAILED, true);
                         bindingResult.reject(LOGIN_FAILURE_ERROR_CODE);
                         return new ModelAndView(LOGIN_VIEW, model.asMap());
@@ -493,12 +498,12 @@ public class AppController {
         return new ModelAndView(LOGIN_VIEW, model.asMap());
     }
 
-    private String authoriseUserDuringLogin(List<String> cookies, HttpServletRequest httpRequest) {
+    private String authoriseUserAfterAuthentication(List<String> cookies, HttpServletRequest httpRequest) {
         String responseUrl = null;
         if (cookies != null) {
             Map<String, String> params = new HashMap<>();
             httpRequest.getParameterMap().forEach((key, values) -> {
-                    if (values.length > 0 && !String.join(" ", values).trim().isEmpty() && !key.equals("prompt"))
+                    if (values.length > 0 && !String.join(" ", values).trim().isEmpty() && !key.equals(PROMPT))
                         params.put(key, String.join(" ", values));
                 }
             );
@@ -538,6 +543,7 @@ public class AppController {
 
     /**
      * @should submit otp authentication using authId cookie and otp code then call authorise and redirect the user
+     * @should submit otp authentication using authId cookie and otp code then call authorise and redirect the user to unexpected response url
      * @should submit otp authentication filtering out Idam.Session cookie to avoid session bugs
      * @should return verification view for INCORRECT_OTP 401 response
      * @should return login view for TOO_MANY_ATTEMPTS_OTP 401 response
@@ -599,15 +605,19 @@ public class AppController {
             final List<String> responseCookies = spiService.submitOtpeAuthentication(authId, ipAddress, request.getCode());
             log.info("/verification: Successful OTP submission request");
 
-            final String responseUrl = authoriseUserDuringLogin(responseCookies, httpRequest);
+            final String responseUrl = authoriseUserAfterAuthentication(responseCookies, httpRequest);
             final boolean loginSuccess = responseUrl != null && !responseUrl.contains("error");
             if (loginSuccess) {
-                log.info("/verification: Successful login");
+                if (responseUrl.startsWith(request.getRedirect_uri())) {
+                    log.info("/verification: Successful login");
+                } else {
+                    log.info("/verification: Successful login with unexpected redirect {}", responseUrl);
+                }
                 List<String> secureCookies = authHelper.makeCookiesSecure(responseCookies);
                 secureCookies.forEach(cookie -> response.addHeader(HttpHeaders.SET_COOKIE, cookie));
                 return new ModelAndView(REDIRECT_PREFIX + responseUrl);
             } else {
-                log.info("/verification: There is a problem while logging in user");
+                log.info("/verification: There is a problem while logging in user, response url is {}", responseUrl != null ? responseUrl : "n/a");
                 return redirectToLoginOnFailedOtpVerification(request, bindingResult, model);
             }
         } catch (HttpClientErrorException | HttpServerErrorException he) {

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/strategic/StepUpAuthenticationZuulFilter.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/strategic/StepUpAuthenticationZuulFilter.java
@@ -103,8 +103,7 @@ public class StepUpAuthenticationZuulFilter extends ZuulFilter {
     }
 
     protected boolean isPromptLogin(HttpServletRequest request) {
-        String promptValue = request.getParameter(PROMPT_PARAMETER);
-        return StringUtils.isNotEmpty(promptValue) && promptValue.equals(PROMPT_LOGIN_VALUE);
+        return StringUtils.equalsIgnoreCase(request.getParameter(PROMPT_PARAMETER), PROMPT_LOGIN_VALUE);
     }
 
     protected boolean hasSessionCookie(@Nonnull final HttpServletRequest request) {

--- a/src/test/java/uk/gov/hmcts/reform/idam/web/AppControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/web/AppControllerTest.java
@@ -57,6 +57,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -1413,11 +1414,24 @@ public class AppControllerTest {
             .param(STATE_PARAMETER, STATE)
             .param(RESPONSE_TYPE_PARAMETER, RESPONSE_TYPE)
             .param(CLIENT_ID_PARAMETER, CLIENT_ID)
-            .param(SCOPE_PARAMETER, CUSTOM_SCOPE))
+            .param(SCOPE_PARAMETER, CUSTOM_SCOPE)
+            .param(PROMPT_PARAMETER, "login"))
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl(REDIRECT_URI));
 
-        verify(spiService).authorize(any(), eq(cookieList));
+        ArgumentCaptor<Map> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(spiService).authorize(paramsCaptor.capture(), eq(cookieList));
+
+        Map<String, String> actualParams = paramsCaptor.getValue();
+        assertThat(actualParams, hasEntry(USERNAME_PARAMETER, USER_EMAIL));
+        assertThat(actualParams, hasEntry(PASSWORD_PARAMETER, USER_PASSWORD));
+        assertThat(actualParams, hasEntry(REDIRECT_URI, REDIRECT_URI));
+        assertThat(actualParams, hasEntry(STATE_PARAMETER, STATE));
+        assertThat(actualParams, hasEntry(RESPONSE_TYPE_PARAMETER, RESPONSE_TYPE));
+        assertThat(actualParams, hasEntry(CLIENT_ID_PARAMETER, CLIENT_ID));
+        assertThat(actualParams, hasEntry(SCOPE_PARAMETER, CUSTOM_SCOPE));
+        assertFalse(actualParams.containsKey("PROMPT_PARAMETER"));
+
     }
 
     /**
@@ -2068,7 +2082,8 @@ public class AppControllerTest {
             .param(RESPONSE_TYPE_PARAMETER, RESPONSE_TYPE)
             .param(CLIENT_ID_PARAMETER, CLIENT_ID)
             .param(SCOPE_PARAMETER, CUSTOM_SCOPE)
-            .param(CODE_PARAMETER, "12345678"))
+            .param(CODE_PARAMETER, "12345678")
+            .param(PROMPT_PARAMETER, "login"))
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl(REDIRECT_URI));
 
@@ -2087,6 +2102,7 @@ public class AppControllerTest {
         assertThat(actualParams, hasEntry(CLIENT_ID_PARAMETER, CLIENT_ID));
         assertThat(actualParams, hasEntry(SCOPE_PARAMETER, CUSTOM_SCOPE));
         assertThat(actualParams, hasEntry(CODE_PARAMETER, "12345678"));
+        assertFalse(actualParams.containsKey(PROMPT_PARAMETER));
     }
 
     /**

--- a/src/test/java/uk/gov/hmcts/reform/idam/web/AppControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/web/AppControllerTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.idam.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.codec.CharEncoding;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -1435,6 +1436,49 @@ public class AppControllerTest {
     }
 
     /**
+     * @verifies put in model correct data then call authorize service and redirect using redirect url returned by service that does not match redirect
+     * @see AppController#login(AuthorizeRequest, BindingResult, Model, HttpServletRequest, HttpServletResponse)
+     */
+    @Test
+    public void login_shouldPutInModelCorrectDataThenCallAuthorizeServiceAndRedirectUsingRedirectUrlReturnedByServiceThatDoesNotMatchRedirect() throws Exception {
+        List<String> cookieList = singletonList(AUTHENTICATE_SESSION_COOKE);
+        ApiAuthResult authResult = ApiAuthResult.builder()
+            .cookies(cookieList)
+            .httpStatus(HttpStatus.OK)
+            .policiesAction(EvaluatePoliciesAction.ALLOW)
+            .build();
+
+        given(spiService.authenticate(eq(USER_EMAIL), eq(USER_PASSWORD), eq(REDIRECT_URI), eq(USER_IP_ADDRESS))).willReturn(authResult);
+        given(spiService.authorize(any(), eq(cookieList))).willReturn("test-redirect");
+
+        mockMvc.perform(post(LOGIN_ENDPOINT).with(csrf())
+            .header(X_FORWARDED_FOR, USER_IP_ADDRESS)
+            .param(USERNAME_PARAMETER, USER_EMAIL)
+            .param(PASSWORD_PARAMETER, USER_PASSWORD)
+            .param(REDIRECT_URI, REDIRECT_URI)
+            .param(STATE_PARAMETER, STATE)
+            .param(RESPONSE_TYPE_PARAMETER, RESPONSE_TYPE)
+            .param(CLIENT_ID_PARAMETER, CLIENT_ID)
+            .param(SCOPE_PARAMETER, CUSTOM_SCOPE)
+            .param(PROMPT_PARAMETER, "login"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("test-redirect"));
+
+        ArgumentCaptor<Map> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(spiService).authorize(paramsCaptor.capture(), eq(cookieList));
+
+        Map<String, String> actualParams = paramsCaptor.getValue();
+        assertThat(actualParams, hasEntry(USERNAME_PARAMETER, USER_EMAIL));
+        assertThat(actualParams, hasEntry(PASSWORD_PARAMETER, USER_PASSWORD));
+        assertThat(actualParams, hasEntry(REDIRECT_URI, REDIRECT_URI));
+        assertThat(actualParams, hasEntry(STATE_PARAMETER, STATE));
+        assertThat(actualParams, hasEntry(RESPONSE_TYPE_PARAMETER, RESPONSE_TYPE));
+        assertThat(actualParams, hasEntry(CLIENT_ID_PARAMETER, CLIENT_ID));
+        assertThat(actualParams, hasEntry(SCOPE_PARAMETER, CUSTOM_SCOPE));
+        assertFalse(actualParams.containsKey("PROMPT_PARAMETER"));
+    }
+
+    /**
      * @verifies put in model correct data if username or  password are empty.
      * @see AppController#login(AuthorizeRequest, BindingResult, Model, HttpServletRequest, HttpServletResponse)
      */
@@ -2086,6 +2130,50 @@ public class AppControllerTest {
             .param(PROMPT_PARAMETER, "login"))
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl(REDIRECT_URI));
+
+        verify(spiService).submitOtpeAuthentication(eq("authId"),
+            eq(USER_IP_ADDRESS),
+            eq("12345678"));
+
+        ArgumentCaptor<Map> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(spiService).authorize(paramsCaptor.capture(), eq(singletonList("Idam.Session=idamSessionCookie")));
+
+        Map<String, String> actualParams = paramsCaptor.getValue();
+        assertThat(actualParams, hasEntry(USERNAME_PARAMETER, USER_EMAIL));
+        assertThat(actualParams, hasEntry(REDIRECT_URI, REDIRECT_URI));
+        assertThat(actualParams, hasEntry(STATE_PARAMETER, STATE));
+        assertThat(actualParams, hasEntry(RESPONSE_TYPE_PARAMETER, RESPONSE_TYPE));
+        assertThat(actualParams, hasEntry(CLIENT_ID_PARAMETER, CLIENT_ID));
+        assertThat(actualParams, hasEntry(SCOPE_PARAMETER, CUSTOM_SCOPE));
+        assertThat(actualParams, hasEntry(CODE_PARAMETER, "12345678"));
+        assertFalse(actualParams.containsKey(PROMPT_PARAMETER));
+    }
+
+    /**
+     * @verifies submit otp authentication using authId cookie and otp code then call authorise and redirect the user to unexpected response url
+     * @see AppController#verification(uk.gov.hmcts.reform.idam.web.model.VerificationRequest, BindingResult, Model, HttpServletRequest, HttpServletResponse)
+     */
+    @Test
+    public void verification_shouldSubmitOtpAuthenticationUsingAuthIdCookieAndOtpCodeThenCallAuthoriseAndRedirectTheUserToUnexpectedResponseUrl() throws Exception {
+        given(spiService.submitOtpeAuthentication(any(), any(), any()))
+            .willReturn(singletonList("Idam.Session=idamSessionCookie"));
+
+        given(spiService.authorize(any(), any()))
+            .willReturn("test-redirect");
+
+        mockMvc.perform(post(VERIFICATION_ENDPOINT).with(csrf())
+            .cookie(new Cookie("Idam.AuthId", "authId"))
+            .header(X_FORWARDED_FOR, USER_IP_ADDRESS)
+            .param(USERNAME_PARAMETER, USER_EMAIL)
+            .param(REDIRECT_URI, REDIRECT_URI)
+            .param(STATE_PARAMETER, STATE)
+            .param(RESPONSE_TYPE_PARAMETER, RESPONSE_TYPE)
+            .param(CLIENT_ID_PARAMETER, CLIENT_ID)
+            .param(SCOPE_PARAMETER, CUSTOM_SCOPE)
+            .param(CODE_PARAMETER, "12345678")
+            .param(PROMPT_PARAMETER, "login"))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("test-redirect"));
 
         verify(spiService).submitOtpeAuthentication(eq("authId"),
             eq(USER_IP_ADDRESS),

--- a/src/test/java/uk/gov/hmcts/reform/idam/web/strategic/StepUpAuthenticationZuulFilterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/web/strategic/StepUpAuthenticationZuulFilterTest.java
@@ -77,23 +77,22 @@ public class StepUpAuthenticationZuulFilterTest {
 
     }
 
-    private Object isAuthorizeRequestParams() {
-        return new Object[]{
-            new Object[]{"http://localhost:1234/o/authorize", "POST", true},
-            new Object[]{"http://localhost:1234/o/authorize", "GET", true},
-            new Object[]{"http://localhost:1234/o/authorize", "PUT", false},
-            new Object[]{"http://localhost:1234/login?param=1", "POST", false},
-            new Object[]{"http://localhost:1234/login?param=1", "GET", false},
-        };
-    }
-
     @Test
-    //@Parameters(method = "isAuthorizeRequestParams")
     public void isAuthorizeRequest() {
         final HttpServletRequest request = mock(HttpServletRequest.class);
         doReturn("http://localhost:1234/o/authorize").when(request).getRequestURI();
         doReturn("POST").when(request).getMethod();
         assertEquals(true, filter.isAuthorizeRequest(request));
+        doReturn("http://localhost:1234/o/authorize").when(request).getRequestURI();
+        doReturn("GET").when(request).getMethod();
+        assertEquals(true, filter.isAuthorizeRequest(request));
+        doReturn("http://localhost:1234/o/authorize").when(request).getRequestURI();
+        doReturn("PUT").when(request).getMethod();
+        assertEquals(false, filter.isAuthorizeRequest(request));
+        doReturn("http://localhost:1234/login?param=1").when(request).getRequestURI();
+        assertEquals(false, filter.isAuthorizeRequest(request));
+        doReturn("http://localhost:1234/login?param=1").when(request).getRequestURI();
+        assertEquals(false, filter.isAuthorizeRequest(request));
     }
 
     @Test

--- a/src/test/js/login_user_functional_test.js
+++ b/src/test/js/login_user_functional_test.js
@@ -96,7 +96,7 @@ Scenario('@functional @loginWithPrompt As a citizen user I can login with prompt
 
     //Webpublic OIDC userinfo
     const oidcUserInfo = await I.retry({retries: 3, minTimeout: 10000}).getWebpublicOidcUserInfo(accessToken);
-    expect(oidcUserInfo.sub.toUpperCase()).to.equal(citizenEmail);
+    expect(oidcUserInfo.sub).to.equal(citizenEmail);
     expect(oidcUserInfo.uid).to.not.equal(null);
     expect(oidcUserInfo.roles).to.eql(['citizen']);
     expect(oidcUserInfo.name).to.equal(randomUserFirstName + 'Citizen' + ' User');

--- a/src/test/js/mfa_e2e_test.js
+++ b/src/test/js/mfa_e2e_test.js
@@ -691,7 +691,10 @@ Scenario('@functional @mfaLogin @mfaSkipStepUpLogin As a user, I can login to th
     const authLocation = await I.getWebPublicOidcAuthorizeWithLogin(mfaTurnedOnService1.oauth2ClientId, mfaTurnedOnService1.activationRedirectUrl, scope, nonce, cookie);
     expect(authLocation).to.includes(`/login?client_id=${mfaTurnedOnService1.oauth2ClientId}&redirect_uri=${mfaTurnedOnService1.activationRedirectUrl}`);
 
-    I.amOnPage(authLocation);
+    const authParams = authLocation.split("/login?")[1];
+    const authLoginUrl = `${TestData.WEB_PUBLIC_URL}/login?${authParams}`
+
+    I.amOnPage(authLoginUrl);
     I.waitForText('Sign in');
     I.fillField('#username', mfaUserEmail);
     I.fillField('#password', userPassword);

--- a/src/test/js/mfa_e2e_test.js
+++ b/src/test/js/mfa_e2e_test.js
@@ -653,3 +653,111 @@ Scenario('@functional @mfaLogin As a user, I can login to the mfa turned off ser
 
     I.resetRequestInterception();
 });
+
+Scenario('@functional @mfaLogin @mfaSkipStepUpLogin As a user, I can login to the MFA turned on service and then authorize to the same service with prompt=login and login again', async ({ I }) => {
+    const nonce = "0km9sBgZfnXv8e_O7U-XmSR6vtIgsUVTXybVUdoLV7g";
+    const loginUrl = `${TestData.WEB_PUBLIC_URL}/login?redirect_uri=${mfaTurnedOnService1.activationRedirectUrl}&client_id=${mfaTurnedOnService1.oauth2ClientId}&state=44p4OfI5CXbdvMTpRYWfleNWIYm6qz0qNDgMOm2qgpU&nonce=${nonce}&response_type=code&scope=${scope}&prompt=`;
+
+    I.amOnPage(loginUrl);
+    I.waitForText('Sign in');
+    I.fillField('#username', mfaUserEmail);
+    I.fillField('#password', userPassword);
+    I.interceptRequestsAfterSignin();
+    I.click('Sign in');
+    I.seeInCurrentUrl("/verification");
+    I.waitForText('Verification required');
+    const otpCode = await I.extractOtpFromNotifyEmail(mfaUserEmail);
+
+    I.fillField('code', otpCode);
+    I.click('Continue');
+    I.waitForText(mfaTurnedOnService1.activationRedirectUrl.toLowerCase());
+    I.see('code=');
+    I.dontSee('error=');
+
+    const mfaturnedOnService1PageSource = await I.grabSource();
+    const mfaturnedOnService1Code = mfaturnedOnService1PageSource.match(/\?code=([^&]*)(.*)/)[1];
+    const mfaturnedOnService1AccessToken = await I.getAccessToken(mfaturnedOnService1Code, mfaTurnedOnService1.oauth2ClientId, mfaTurnedOnService1.activationRedirectUrl, serviceClientSecret);
+
+    let mfaturnedOnService1JwtDecode = await jwt_decode(mfaturnedOnService1AccessToken);
+
+    assert.equal("access_token", mfaturnedOnService1JwtDecode.tokenName);
+    assert.equal(nonce, mfaturnedOnService1JwtDecode.nonce);
+    assert.equal(1, mfaturnedOnService1JwtDecode.auth_level);
+
+    I.amOnPage(loginUrl);
+    const idamSessionCookie = await I.grabCookie('Idam.Session');
+    const cookie = idamSessionCookie.value;
+
+    const authLocation = await I.getWebPublicOidcAuthorizeWithLogin(mfaTurnedOnService1.oauth2ClientId, mfaTurnedOnService1.activationRedirectUrl, scope, nonce, cookie);
+    expect(authLocation).to.includes(`/login?client_id=${mfaTurnedOnService1.oauth2ClientId}&redirect_uri=${mfaTurnedOnService1.activationRedirectUrl}`);
+
+    I.amOnPage(authLocation);
+    I.waitForText('Sign in');
+    I.fillField('#username', mfaUserEmail);
+    I.fillField('#password', userPassword);
+    I.click('Sign in');
+    I.seeInCurrentUrl("/verification");
+    I.waitForText('Verification required');
+    const otpCode2 = await I.extractOtpFromNotifyEmail(mfaUserEmail);
+
+    I.fillField('code', otpCode2);
+    I.click('Continue');
+    I.waitForText(mfaTurnedOnService1.activationRedirectUrl.toLowerCase());
+    I.see('code=');
+    I.dontSee('error=');
+
+    const mfaturnedOnService1PageSource2 = await I.grabSource();
+    const mfaturnedOnService1Code2 = mfaturnedOnService1PageSource2.match(/\?code=([^&]*)(.*)/)[1];
+    const mfaturnedOnService1AccessToken2 = await I.getAccessToken(mfaturnedOnService1Code2, mfaTurnedOnService1.oauth2ClientId, mfaTurnedOnService1.activationRedirectUrl, serviceClientSecret);
+
+    let mfaturnedOnService1JwtDecode2 = await jwt_decode(mfaturnedOnService1AccessToken2);
+
+    assert.equal("access_token", mfaturnedOnService1JwtDecode2.tokenName);
+    assert.equal(nonce, mfaturnedOnService1JwtDecode2.nonce);
+    assert.equal(1, mfaturnedOnService1JwtDecode2.auth_level);
+
+    I.amOnPage(loginUrl);
+    const idamSessionCookie2 = await I.grabCookie('Idam.Session');
+    const cookie2 = idamSessionCookie2.value;
+
+    // try authorizing to the mfa turned on service with the Idam session cookie and prompt not login
+    const location2 = await I.getWebPublicOidcAuthorize(mfaTurnedOnService1.oauth2ClientId, mfaTurnedOnService1.activationRedirectUrl, scope, nonce, cookie2);
+    console.log("Location: " + location2);
+    expect(location2).to.includes(`${mfaTurnedOnService1.activationRedirectUrl}/?code=`.toLowerCase());
+
+    I.amOnPage(location2);
+    I.waitForText(mfaTurnedOnService1.activationRedirectUrl.toLowerCase());
+    I.see('code=');
+    I.dontSee('error=');
+
+    const mfaTurnedOnService1PageSource3 = await I.grabSource();
+    const mfaTurnedOnService1Code3 = mfaTurnedOnService1PageSource3.match(/\?code=([^&]*)(.*)/)[1];
+    const mfaTurnedOnService1AccessToken3 = await I.getAccessToken(mfaTurnedOnService1Code3, mfaTurnedOnService1.oauth2ClientId, mfaTurnedOnService1.activationRedirectUrl, serviceClientSecret);
+
+    let mfaturnedOnService1JwtDecode3 = await jwt_decode(mfaTurnedOnService1AccessToken3);
+
+    assert.equal("access_token", mfaturnedOnService1JwtDecode3.tokenName);
+    assert.equal(nonce, mfaturnedOnService1JwtDecode3.nonce);
+    assert.equal(1, mfaturnedOnService1JwtDecode3.auth_level);
+
+    //Details api
+    const userInfo = await I.retry({retries: 3, minTimeout: 10000}).getUserInfo(mfaTurnedOnService1AccessToken3);
+    expect(userInfo.active).to.equal(true);
+    expect(userInfo.email).to.equal(mfaUserEmail);
+    expect(userInfo.forename).to.equal(randomUserFirstName);
+    expect(userInfo.id).to.not.equal(null);
+    expect(userInfo.surname).to.equal('User');
+    expect(userInfo.roles).to.deep.equalInAnyOrder([mfaTurnedOffServiceRole.name, mfaTurnedOnServiceRole.name]);
+
+    //Webpublic OIDC userinfo
+    const oidcUserInfo = await I.retry({retries: 3, minTimeout: 10000}).getWebpublicOidcUserInfo(mfaTurnedOnService1AccessToken3);
+    expect(oidcUserInfo.sub.toUpperCase()).to.equal(mfaUserEmail.toUpperCase());
+    expect(oidcUserInfo.uid).to.not.equal(null);
+    expect(oidcUserInfo.roles).to.deep.equalInAnyOrder([mfaTurnedOffServiceRole.name, mfaTurnedOnServiceRole.name]);
+
+    expect(oidcUserInfo.name).to.equal(randomUserFirstName + ' User');
+    expect(oidcUserInfo.given_name).to.equal(randomUserFirstName);
+    expect(oidcUserInfo.family_name).to.equal('User');
+
+    I.resetRequestInterception();
+});

--- a/src/test/js/shared/idam_helper.js
+++ b/src/test/js/shared/idam_helper.js
@@ -109,6 +109,22 @@ class IdamHelper extends Helper {
             });
     }
 
+    getWebPublicOidcAuthorizeWithLogin(serviceName, serviceRedirect, oauth2Scope, nonce, cookie) {
+        return fetch(`${TestData.WEB_PUBLIC_URL}/o/authorize?redirect_uri=${serviceRedirect}&client_id=${serviceName}&state=44p4OfI5CXbdvMTpRYWfleNWIYm6qz0qNDgMOm2qgpU&nonce=${nonce}&response_type=code&scope=${oauth2Scope}&prompt=login`, {
+            agent: agent,
+            method: 'GET',
+            headers: {'Cookie': `Idam.Session=${cookie}`},
+            redirect: 'manual'
+        }).then(response => {
+            return response.headers.get('Location');
+        })
+            .catch(err => {
+                console.log(err);
+                let browser = this.helpers['Puppeteer'].browser;
+                browser.close();
+            });
+    }
+
     createService(serviceName, serviceClientSecret, roleId, token, scope = '', ssoProviders = '') {
         let data;
 

--- a/src/test/js/shared/idam_helper.js
+++ b/src/test/js/shared/idam_helper.js
@@ -109,7 +109,7 @@ class IdamHelper extends Helper {
             });
     }
 
-    getWebPublicOidcAuthorizeWithLogin(serviceName, serviceRedirect, oauth2Scope, nonce, cookie) {
+    getWebPublicOidcAuthorizeWithLoginRequired(serviceName, serviceRedirect, oauth2Scope, nonce, cookie) {
         return fetch(`${TestData.WEB_PUBLIC_URL}/o/authorize?redirect_uri=${serviceRedirect}&client_id=${serviceName}&state=44p4OfI5CXbdvMTpRYWfleNWIYm6qz0qNDgMOm2qgpU&nonce=${nonce}&response_type=code&scope=${oauth2Scope}&prompt=login`, {
             agent: agent,
             method: 'GET',


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-6295

### Change description ###

Skip stepup filter if prompt=login.
Don't pass "prompt" parameter to api calls for authorize done during login/verification since it results in AM throwing a 500 which redirects back to login.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
