### PR TITLE
SIDM-7110: Upgrade tomcat to latest to address CVE-2022-23181

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ allprojects {
   targetCompatibility = 11
 
   def idamBomVersion = '2.8.14'
+  // Remove when Spring Boot Dependencies upgrades their tomcat version and idam-bom is upgraded accordingly
+  ext['tomcat.version'] = '9.0.58'
 
   configurations.all {
     exclude group: "org.glassfish", module: "jakarta.el"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-7110


### Change description ###
Upgrade tomcat to latest 9.0.x version to address a CVE.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
