### PR TITLE
SIDM-7556: Tests: Complete SSO flow before deleting the federated user

### DIFF
--- a/src/test/js/ejudiciary_login_test.js
+++ b/src/test/js/ejudiciary_login_test.js
@@ -130,6 +130,18 @@ Scenario('@functional @ejudiciary As an ejudiciary user, I should be redirected 
     I.click('Sign in');
 
     I.waitForText('Stay signed in?');
-    I.click('No');
+
+    if (TestData.WEB_PUBLIC_URL.includes("-pr-") || TestData.WEB_PUBLIC_URL.includes("staging")) {
+        I.click('No');
+        // expected to be not redirected with the code for pr and staging urls as they're not registered with AAD.
+        I.waitInUrl("/kmsi");
+        I.see("Make sure the redirect URI sent in the request matches one added to your application in the Azure portal");
+    } else {
+        I.interceptRequestsAfterSignin();
+        I.click('No');
+        I.waitForText(TestData.SERVICE_REDIRECT_URI);
+        I.see('code=');
+        I.resetRequestInterception();
+    }
 
 }).retry(TestData.SCENARIO_RETRY_LIMIT);

--- a/src/test/js/moj_login_test.js
+++ b/src/test/js/moj_login_test.js
@@ -137,6 +137,17 @@ Scenario('@functional @moj As a Justice.gov.uk user, I should be redirected to M
     I.click('Sign in');
 
     I.waitForText('Stay signed in?');
-    I.click('No');
+
+    if (TestData.WEB_PUBLIC_URL.includes("-pr-") || TestData.WEB_PUBLIC_URL.includes("staging")) {
+        I.click('No');
+        // expected to be not redirected with the code for pr and staging urls as they're not registered with AAD.
+        I.waitInUrl("/kmsi");
+        I.see("Make sure the redirect URI sent in the request matches one added to your application in the Azure portal");
+    } else {
+        I.interceptRequestsAfterSignin();
+        I.click('No');
+        I.waitForText(TestData.SERVICE_REDIRECT_URI);
+        I.see('code=');
+    }
 
 }).retry(TestData.SCENARIO_RETRY_LIMIT);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-7556


### Change description ###
2 of our SSO tests do not wait for the SSO flow to complete before attempting to delete the SSO user. 
This caused a nightly pipeline to fail as there was a race condition between the DELETE user operation triggered by the test and the UPDATE user operation triggered by the SSO flow.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
