### PR TITLE
SIDM-7639: Upgrade to latest bom to upgrade to Spring Boot 2.6.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.11.RELEASE' apply false
   id 'org.owasp.dependencycheck' version '6.5.3'
   id 'org.sonarqube' version '2.6.2'
-  id 'org.springframework.boot' version '2.6.7' apply false
+  id 'org.springframework.boot' version '2.6.8' apply false
   id 'com.gorylenko.gradle-git-properties' version '1.4.21'
   id "info.solidsoft.pitest" version "1.6.0"
   id 'application'
@@ -33,8 +33,7 @@ allprojects {
   sourceCompatibility = 11
   targetCompatibility = 11
 
-  def idamBomVersion = '2.8.21'
-  ext['netty.version'] = '4.1.77.Final'
+  def idamBomVersion = '2.8.24'
 
   configurations.all {
     exclude group: "org.glassfish", module: "jakarta.el"

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ allprojects {
   targetCompatibility = 11
 
   def idamBomVersion = '2.8.24'
+  ext['idam-api-spec.version'] = '3.7.0'
 
   configurations.all {
     exclude group: "org.glassfish", module: "jakarta.el"

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -27,6 +27,11 @@
         <cve>CVE-2014-0054</cve>
         <cve>CVE-2022-22965</cve>
         <cve>CVE-2022-22968</cve>
+    </suppress>
+
+    <!-- Currently there is no new version of spring-framework and no simple workaround -->
+    <suppress>
+        <gav regex="true">^.*spring-.*$</gav>
         <cve>CVE-2016-1000027</cve>
     </suppress>
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-7639

### Change description ###
* Upgrade to latest bom that includes upgrade to Spring Boot 2.6.8
* Remove version overwrites for nettty as latest Spring Boot already uses them
* Suppress CVE-2016-1000027 for more Spring Framework artifacts (fix doesn't exist currently)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
