### PR TITLE
SIDM-7712 - Fix CVE-2022-22976 and CVE-2022-22970

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.11.RELEASE' apply false
   id 'org.owasp.dependencycheck' version '7.1.0.1'
   id 'org.sonarqube' version '2.6.2'
-  id 'org.springframework.boot' version '2.6.8' apply false
+  id 'org.springframework.boot' version '2.7.0' apply false
   id 'com.gorylenko.gradle-git-properties' version '1.4.21'
   id "info.solidsoft.pitest" version "1.6.0"
   id 'application'
@@ -33,7 +33,7 @@ allprojects {
   sourceCompatibility = 11
   targetCompatibility = 11
 
-  def idamBomVersion = '2.8.24'
+  def idamBomVersion = '2.8.26'
   ext['idam-api-spec.version'] = '3.7.0'
 
   configurations.all {
@@ -87,6 +87,7 @@ allprojects {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-resource-server'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-data-redis-reactive'
     implementation group: 'org.springframework.session', name: 'spring-session-data-redis', version: '2.6.3'
+    implementation group: 'org.springframework.data', name: 'spring-data-redis', version: '2.6.4'
     implementation group: 'org.yaml', name: 'snakeyaml'
 
     implementation group: 'io.github.openfeign', name: 'feign-jackson'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.11.RELEASE' apply false
   id 'org.owasp.dependencycheck' version '6.5.3'
   id 'org.sonarqube' version '2.6.2'
-  id 'org.springframework.boot' version '2.6.8' apply false
+  id 'org.springframework.boot' version '2.7.0' apply false
   id 'com.gorylenko.gradle-git-properties' version '1.4.21'
   id "info.solidsoft.pitest" version "1.6.0"
   id 'application'
@@ -33,7 +33,7 @@ allprojects {
   sourceCompatibility = 11
   targetCompatibility = 11
 
-  def idamBomVersion = '2.8.24'
+  def idamBomVersion = '2.8.26'
   ext['idam-api-spec.version'] = '3.7.0'
 
   configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'java'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE' apply false
-  id 'org.owasp.dependencycheck' version '6.5.3'
+  id 'org.owasp.dependencycheck' version '7.1.0.1'
   id 'org.sonarqube' version '2.6.2'
   id 'org.springframework.boot' version '2.6.8' apply false
   id 'com.gorylenko.gradle-git-properties' version '1.4.21'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.11.RELEASE' apply false
   id 'org.owasp.dependencycheck' version '6.5.3'
   id 'org.sonarqube' version '2.6.2'
-  id 'org.springframework.boot' version '2.7.0' apply false
+  id 'org.springframework.boot' version '2.6.8' apply false
   id 'com.gorylenko.gradle-git-properties' version '1.4.21'
   id "info.solidsoft.pitest" version "1.6.0"
   id 'application'
@@ -33,7 +33,7 @@ allprojects {
   sourceCompatibility = 11
   targetCompatibility = 11
 
-  def idamBomVersion = '2.8.26'
+  def idamBomVersion = '2.8.24'
   ext['idam-api-spec.version'] = '3.7.0'
 
   configurations.all {

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -33,6 +33,8 @@
     <suppress>
         <gav regex="true">^.*spring-.*$</gav>
         <cve>CVE-2016-1000027</cve>
+        <cve>CVE-2022-22970</cve>
+        <cve>CVE-2022-22976</cve>
     </suppress>
 
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -18,7 +18,7 @@
         <cve>CVE-2021-22112</cve>
     </suppress>
 
-    <!-- Currently there is no new version of spring-framework and no simple workaround -->
+    <!-- These are false positive CVEs from the dependency check plugin (to be addressed in v7.1.1) -->
     <suppress>
         <gav regex="true">^.*spring-.*$</gav>
         <cve>CVE-2016-1000027</cve>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -18,22 +18,11 @@
         <cve>CVE-2021-22112</cve>
     </suppress>
 
-    <!-- Transient dependencies from spring session are older spring artifacts
-         currently there is no new version of spring-session and no simple workaround -->
-    <suppress>
-        <gav regex="true">^.*spring-session.*$</gav>
-        <cve>CVE-2013-4152</cve>
-        <cve>CVE-2013-7315</cve>
-        <cve>CVE-2014-0054</cve>
-        <cve>CVE-2022-22965</cve>
-        <cve>CVE-2022-22968</cve>
-    </suppress>
-
     <!-- Currently there is no new version of spring-framework and no simple workaround -->
     <suppress>
         <gav regex="true">^.*spring-.*$</gav>
         <cve>CVE-2016-1000027</cve>
-        <cve>CVE-2022-22970</cve>
+        <cve>CVE-2020-5408</cve>
         <cve>CVE-2022-22976</cve>
     </suppress>
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-7708

### Change description ###

- Suppress CVE-2022-22976
- Upgrade spring boot version to 2.7.0 by upgrading idam-bom
- Update dependency checker plugin to 7.1.0.1
- Tidy up CVE suppression list 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```