### PR TITLE
SIDM-8141: Upgrade jackson databind to address CVE-2022-42004

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ allprojects {
 
     implementation group: 'javax.servlet', name: 'jstl'
     implementation group: 'javax.json', name: 'javax.json-api'
-    implementation (group: 'com.fasterxml.jackson.core', name: 'jackson-databind')
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.0'
     implementation group: 'org.apache.httpcomponents', name: 'httpclient'
     implementation group: 'org.apache.httpcomponents', name: 'httpcore'
     implementation group: 'org.apache.commons', name: 'commons-text'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'java'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE' apply false
-  id 'org.owasp.dependencycheck' version '7.1.0.1'
+  id 'org.owasp.dependencycheck' version '7.2.1'
   id 'org.sonarqube' version '2.6.2'
   id 'org.springframework.boot' version '2.7.0' apply false
   id 'com.gorylenko.gradle-git-properties' version '1.4.21'
@@ -107,7 +107,7 @@ allprojects {
 
     implementation group: 'javax.servlet', name: 'jstl'
     implementation group: 'javax.json', name: 'javax.json-api'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.14.0'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.4'
     implementation group: 'org.apache.httpcomponents', name: 'httpclient'
     implementation group: 'org.apache.httpcomponents', name: 'httpcore'
     implementation group: 'org.apache.commons', name: 'commons-text'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -18,13 +18,11 @@
         <cve>CVE-2021-22112</cve>
     </suppress>
 
-    <!-- These are false positive CVEs from the dependency check plugin (to be addressed in v7.1.1) -->
+    <!-- These are false positive CVEs from the dependency check plugin -->
     <suppress>
         <gav regex="true">^.*spring-.*$</gav>
         <cve>CVE-2016-1000027</cve>
         <cve>CVE-2020-5408</cve>
-        <cve>CVE-2022-22976</cve>
-        <cve>CVE-2022-22978</cve>
     </suppress>
 
     <suppress>
@@ -33,14 +31,8 @@
     </suppress>
 
     <suppress>
-        <gav regex="true">^.*log4j-.*$</gav>
-        <cve>CVE-2022-33915</cve>
-    </suppress>
-
-    <!-- Bug in plugin https://github.com/jeremylong/DependencyCheck/issues/4671 -->
-    <suppress>
-        <gav regex="true">^.*$</gav>
-        <cve>CVE-2022-31569</cve>
+        <gav regex="true">^.*jackson-databind.*$</gav>
+        <cve>CVE-2022-42003</cve>
     </suppress>
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-8141


### Change description ###
* Latest jackson databind.
* Suppress CVE-2022-42003 as no GA release with a fix exists.
* Upgrade OWASP dependency check plugin.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
