### PR TITLE
update test for multiple users can be registered with same uuid

### DIFF
--- a/src/test/js/user_registration_with_the_same_uuid_in_pending_status_test.js
+++ b/src/test/js/user_registration_with_the_same_uuid_in_pending_status_test.js
@@ -66,7 +66,7 @@ AfterSuite(async ({ I }) => {
     return await I.deleteAllTestData(randomData.TEST_BASE_PREFIX + testSuitePrefix);
 });
 
-Scenario('@functional multiple users can be registered with same uuid but the previous user will be assigned with auto generated uuid upon activation', async ({ I }) => {
+Scenario('@functional multiple users can be registered with same uuid but the previous user will be told their account is already active', async ({ I }) => {
     const responseBeforeActivation = await I.getUserById(userId, accessToken);
     expect(responseBeforeActivation.id).to.equal(userId);
     expect(responseBeforeActivation.pending).to.equal(true);
@@ -93,17 +93,6 @@ Scenario('@functional multiple users can be registered with same uuid but the pr
     const previousUserUrl = await I.extractUrlFromNotifyEmail(accessTokenClientSecret, previousUserEmail);
 
     I.amOnPage(previousUserUrl);
-    I.waitForText('Create a password');
-    I.fillField('#password1', userPassword);
-    I.fillField('#password2', userPassword);
-    I.click('Continue');
-    I.waitForText('Account created');
-    userFirstNames.push(randomUserFirstName);
+    I.waitForText('Your account is already activated.');
 
-    const responseAfterPreviousUserActivation = await I.getUserByEmail(previousUserEmail);
-    expect(responseAfterPreviousUserActivation.id).to.not.equal(userId);
-    expect(responseAfterPreviousUserActivation.active).to.equal(true);
-    expect(responseAfterPreviousUserActivation.forename).to.equal(randomUserFirstName);
-    expect(responseAfterPreviousUserActivation.surname).to.equal(randomUserLastName);
-    expect(responseAfterPreviousUserActivation.email).to.equal(previousUserEmail);
 });


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-8244

### Change description ###

The existing functional test "multiple users can be registered with same uuid but the previous user will be assigned with auto generated uuid upon activation" seems to be invalid.

It worked because the old pending user code would only allow a single "pending user" to be stored in cluster cache with a specific user id, which it ensured by deleting older entries for the same user id when you created a new one. However, it didn't delete the token from the cluster cache, which meant that you could still activate a user for an older email, but key pieces of information on that user (for example their roles) would not be present because they would have been deleted.

Because of that it looks like this test worked by accident, and did not result in the outcome that it thought it did. After the test is run you would have had one active user that was correctly setup with roles, and one active user that was only partially setup (no roles, no activation service etc.)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
