### PR TITLE
SIDM-8300: Upgrade OWASP dependency check plugin

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -10,29 +10,11 @@
         <cve>CVE-2015-0254</cve>
     </suppress>
 
-    <!-- False positive on CVE-2018-1258. See https://github.com/jeremylong/DependencyCheck/issues/1827 -->
-    <!-- CVE-2021-22112 cannot be externally exploited and needs to be programmed in. -->
-    <suppress>
-        <gav regex="true">^.*spring-boot-starter-oauth2.*$</gav>
-        <cve>CVE-2018-1258</cve>
-        <cve>CVE-2021-22112</cve>
-    </suppress>
-
     <!-- These are false positive CVEs from the dependency check plugin -->
     <suppress>
         <gav regex="true">^.*spring-.*$</gav>
         <cve>CVE-2016-1000027</cve>
         <cve>CVE-2020-5408</cve>
-    </suppress>
-
-    <suppress>
-        <gav regex="true">^.*tomcat-.*$</gav>
-        <cve>CVE-2022-34305</cve>
-    </suppress>
-
-    <suppress>
-        <gav regex="true">^.*jackson-databind.*$</gav>
-        <cve>CVE-2022-42003</cve>
     </suppress>
 
 </suppressions>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ feign = ["feign-jackson", "feign-okhttp", "spring-cloud-openfeign"]
 jmh = { id = "me.champeau.jmh", version = "0.6.5" }
 spring = { id = "io.spring.dependency-management", version = "1.1.0" }
 spring-framework = { id = "org.springframework.boot", version.ref = "spring-boot" }
-owasp = { id = "org.owasp.dependencycheck", version = "7.3.0" }
+owasp = { id = "org.owasp.dependencycheck", version = "7.4.1" }
 sonarqube = { id = "org.sonarqube", version = "2.8" }
 pitest = { id = "info.solidsoft.pitest", version = "1.6.0" }
 git-properties = { id = "com.gorylenko.gradle-git-properties", version = "1.4.21" }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-8300


### Change description ###
The CVE affects commons .net libraries which are not used by Java applications - however, OWASP dependency-check plugin prior to v7.4.1 reports it as a vulnerability across a number of common-* Java libraries. The latest version of the plugin fixes the problem.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
