### PR TITLE
SIDM-8310: Handle RequestRejectedExceptions

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/idam/web/config/IdamWebMvcConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/config/IdamWebMvcConfiguration.java
@@ -90,7 +90,7 @@ public class IdamWebMvcConfiguration implements WebMvcConfigurer {
         return new HttpStatusRequestRejectedHandler(HttpStatus.BAD_REQUEST.value()) {
             @Override
             public void handle(HttpServletRequest request, HttpServletResponse response, RequestRejectedException requestRejectedException) throws IOException {
-                log.error("Request rejected due to Spring Security - ", requestRejectedException);
+                log.error("Request rejected due to Spring Security", requestRejectedException);
                 response.sendError(HttpStatus.BAD_REQUEST.value());
             }
         };

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/config/IdamWebMvcConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/config/IdamWebMvcConfiguration.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.idam.web.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.tomcat.util.http.Rfc6265CookieProcessor;
 import org.apache.tomcat.util.http.SameSiteCookies;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,7 +8,11 @@ import org.springframework.boot.web.embedded.tomcat.TomcatContextCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.CacheControl;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.web.firewall.HttpStatusRequestRejectedHandler;
+import org.springframework.security.web.firewall.RequestRejectedException;
+import org.springframework.security.web.firewall.RequestRejectedHandler;
 import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -17,6 +22,11 @@ import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
 import org.springframework.web.servlet.mvc.WebContentInterceptor;
 import uk.gov.hmcts.reform.idam.web.config.properties.ConfigurationProperties;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
 @Configuration
 public class IdamWebMvcConfiguration implements WebMvcConfigurer {
 
@@ -75,6 +85,16 @@ public class IdamWebMvcConfiguration implements WebMvcConfigurer {
         return new RequestMethodInterceptor();
     }
 
+    @Bean
+    public RequestRejectedHandler requestRejectedHandler() {
+        return new HttpStatusRequestRejectedHandler(HttpStatus.BAD_REQUEST.value()) {
+            @Override
+            public void handle(HttpServletRequest request, HttpServletResponse response, RequestRejectedException requestRejectedException) throws IOException {
+                log.error("Request rejected due to Spring Security - ", requestRejectedException);
+                response.sendError(HttpStatus.BAD_REQUEST.value());
+            }
+        };
+    }
     /**
      * return HTML by default when not sure.
      */

--- a/src/test/java/uk/gov/hmcts/reform/idam/web/config/AppConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/web/config/AppConfigurationTest.java
@@ -53,9 +53,9 @@ public class AppConfigurationTest {
 
     @Test
     public void disallowed_http_methods_should_return_http_400() throws Exception {
-        MockHttpServletRequestBuilder requestWithPotentiallyMaliciousString = MockMvcRequestBuilders.
+        MockHttpServletRequestBuilder requestWithNotAllowedHttpMethod = MockMvcRequestBuilders.
             request("DEBUG", URI.create("/"));
-        mvc.perform(requestWithPotentiallyMaliciousString)
+        mvc.perform(requestWithNotAllowedHttpMethod)
             .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/idam/web/config/AppConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/web/config/AppConfigurationTest.java
@@ -17,7 +17,7 @@ import java.net.URI;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(value = IdamWebMvcConfiguration.class)
+@WebMvcTest
 @AutoConfigureMockMvc
 @RunWith(SpringRunner.class)
 @TestPropertySource(properties = {"testing=true", "features.federated-s-s-o=false"})


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-8310

### Change description ###
Spring Security blocks suspicious requests (e.g. requests that include double slashes, or disallowed HTTP methods) and returns HTTP 500 Internal Server Error by default.
This PR changes the reponse code to HTTP 400 Bad Request.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
