### PR TITLE
SIDM-8348: False positive in snakeyaml (CVE-2021-4235, CVE-2022-3064)

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -21,6 +21,11 @@
         <packageUrl regex="true">^pkg:maven/org\.latencyutils/LatencyUtils@.*$</packageUrl>
         <cve>CVE-2021-4277</cve>
     </suppress>
-
+    <!-- False positive:  https://github.com/jeremylong/DependencyCheck/issues/5233  -->
+    <suppress>
+        <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+        <cve>CVE-2021-4235</cve>
+        <cve>CVE-2022-3064</cve>
+    </suppress>
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-8348


### Change description ###
CVE suppressed due to https://github.com/jeremylong/DependencyCheck/issues/5233.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
