### PR TITLE
Temporarily revert zap-cli changes

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -14,7 +14,7 @@ properties([
     ])
 ])
 
-@Library("Infrastructure") _
+@Library("Infrastructure@zap-cli-docker-idam") _
 import uk.gov.hmcts.contino.GradleBuilder
 
 GradleBuilder builder = new GradleBuilder(this, 'jenkins-library')


### PR DESCRIPTION
### Change description ###
This is using a branch of the cnp-jenkins-library repo which is using the older zap2docker image which contains zap-cli
zap-cli is now deprecated and security scripts should be updated to the new format
Example for frontend script: https://github.com/hmcts/cnp-jenkins-library/blob/master/resources/uk/gov/hmcts/pipeline/security/frontend/security.sh
Example for backend script: https://github.com/hmcts/cnp-jenkins-library/blob/master/resources/uk/gov/hmcts/pipeline/security/backend/security.sh


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
