### PR TITLE
SIDM-9199: Fix broken reset password link

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/forgotpasswordsuccess.jsp
+++ b/src/main/webapp/WEB-INF/jsp/forgotpasswordsuccess.jsp
@@ -21,7 +21,7 @@
                     <p>
                         <spring:message code="public.forgot.password.success.unconnected.account"/>
                         <c:url value="/users/selfRegister" var="selfRegisterUrl">
-                            <c:param name="redirect_uri" value="${redirectUri}" />
+                            <c:param name="redirectUri" value="${redirectUri}" />
                             <c:param name="client_id" value="${client_id}" />
                             <c:param name="state" value="${state}" />
                             <c:param name="nonce" value="${nonce}" />


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-9199


### Change description ###
Correct the name of the redirect_uri parameter - that is important for rendering the Continue button at the end of the password reset journey.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
