### PR TITLE
Do not use PRD for tests as it is down

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -61,8 +61,8 @@ withPipeline(type, product, component) {
     }
 
     before('functionalTest:aat') {
-        env.RPE_AUTH_URL = "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
-        env.REF_DATA_URL = "http://rd-professional-api-aat.service.core-compute-aat.internal"
+        //env.RPE_AUTH_URL = "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
+        //env.REF_DATA_URL = "http://rd-professional-api-aat.service.core-compute-aat.internal"
         env.IDAMAPI = "https://idam-api.aat.platform.hmcts.net"
         env.TESTING_SUPPORT_API_URL = 'https://idam-testing-support-api.aat.platform.hmcts.net'
         env.TESTS_FOR_ACCESSIBILITY = true


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
RD User Profie is down (see [here](https://tools.hmcts.net/jira/browse/DTSPO-18964)) which breaks our MFA tests. This change switches the tests to use our mock PRD endpoint instead.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
