### PR TITLE
Upgrade spring framework to address CVE-2024-22259

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ allprojects {
   ext['okhttp.version'] = '4.11.0'
   ext['netty.version'] = '4.1.121.Final' // CVE-2023-44487
   ext['jackson.version'] = '2.16.2'
+  ext['spring-framework.version'] = '5.3.33'
 
   repositories {
     mavenCentral()


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Bump Spring Framework. We cannot update Spring Boot as we are on the latest 2.x version and upgrading to 3.x is a no-go as it does not support JSPs.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
