### PR TITLE
Suppress CVE-2025-46392 as there is no upgrade path

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -23,4 +23,13 @@
         <cve>CVE-2023-6378</cve>
         <cve>CVE-2023-6481</cve>
     </suppress>
+
+    <!--
+    commons-configuration-1.8 is a transitive dependency of spring-cloud-starter-netflix-zuul:
+    neither has an upgrade path
+    -->
+    <suppress>
+        <gav regex="true">^.*commons-configuration.*$</gav>
+        <cve>CVE-2025-46392</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
CVE-2025-46392 has been identified in Apache Commons Configuration 1.8 (last updated in 2013 and now moved into Commons Configuration2) - this is a transitive dependency of Spring Cloud Starter Netflix Zuul 2.2.10 which was last updated in 2021. 
As we cannot upgrade, we should suppress.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
