### PR TITLE
Test fix: allow additional roles for the test ejudiciary SSO user

### DIFF
--- a/src/test/js/ejudiciary_login_test.js
+++ b/src/test/js/ejudiciary_login_test.js
@@ -65,7 +65,7 @@ Scenario('@functional @ejudiciary As an ejudiciary user, I can login into idam t
         expect(userInfo.forename).to.equal('SIDM EJUD');
         expect(userInfo.surname).to.equal('TEST A');
         expect(userInfo.id).to.not.equal(null);
-        expect(userInfo.roles).to.eql(['judiciary']);
+        expect(userInfo.roles).to.include('judiciary');
     }
 
     I.resetRequestInterception();
@@ -110,7 +110,7 @@ Scenario('@functional @ejudiciary As an ejudiciary user, I should be able to log
         expect(userInfo.forename).to.equal('SIDM EJUD');
         expect(userInfo.surname).to.equal('TEST A');
         expect(userInfo.id).to.not.equal(null);
-        expect(userInfo.roles).to.eql(['judiciary']);
+        expect(userInfo.roles).to.include('judiciary');
 
         I.resetRequestInterception();
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
'judiciary' role should be one of the roles of the test SSO user but maybe not the only one.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
