### PR TITLE
Mitigate Spring Security CVE-2026-22732

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -43,4 +43,15 @@
         <sha1>12F6E48253F9CAFA0E24D7D232FF504C52143212</sha1>
         <cve>CVE-2026-33540</cve>
     </suppress>
+
+    <!--
+    Spring's advisory for CVE-2026-22732 lists 5.7.22 as the fixed 5.7.x release, but that line is
+    enterprise-support-only. This application applies Spring's documented workaround by forcing eager
+    header writing in both security configurations, which addresses the vulnerable behavior while the
+    project remains on the public Spring Boot 2.7 / Spring Security 5.7 line.
+    -->
+    <suppress>
+        <gav regex="true">^.*org\.springframework\.security:spring-security-.*$</gav>
+        <cve>CVE-2026-22732</cve>
+    </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/idam/web/config/SpringSecurityHeaderWriterConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/web/config/SpringSecurityHeaderWriterConfiguration.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.reform.idam.web.config;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.header.HeaderWriterFilter;
+
+@Configuration
+public class SpringSecurityHeaderWriterConfiguration {
+
+    @Bean
+    public static BeanPostProcessor eagerHeaderWriterFilterBeanPostProcessor() {
+        return new BeanPostProcessor() {
+            @Override
+            public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+                if (bean instanceof HeaderWriterFilter headerWriterFilter) {
+                    headerWriterFilter.setShouldWriteHeadersEagerly(true);
+                }
+                return bean;
+            }
+        };
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
Support.


### Change description ###
Mitigates CVE-2026-22732 for the current Spring Security 5.7.x line used by this service.
*  Spring’s advisory marks 5.7.22 as the fix for 5.7.x, but that release is enterprise-support-only. Since this application remains on public Spring Boot 2.7 / Spring Security 5.7, this PR applies Spring’s documented workaround instead.

#### Changes
  - Add a Spring BeanPostProcessor that forces HeaderWriterFilter.shouldWriteHeadersEagerly=true
  - Apply that mitigation globally to the application’s Spring Security configuration
  - Add a targeted OWASP Dependency Check suppression for CVE-2026-22732 with rationale documented in the suppression file

#### Why

  CVE-2026-22732 affects servlet applications where Spring Security may fail to write configured HTTP security headers under some conditions. This service explicitly relies on those headers, so forcing eager header writing addresses the
  vulnerable behavior without requiring a larger framework upgrade.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
