### PR TITLE
Suppress non-exploitable Spring CVEs in dependency-check

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -63,7 +63,7 @@
     application endpoints beneath a Cloud Foundry actuator path.
     -->
     <suppress>
-        <gav regex="true">^.*org\.springframework\.boot:spring-boot(-actuator|-actuator-autoconfigure)?$</gav>
+        <gav regex="true">^.*org\.springframework\.boot:.*$</gav>
         <cve>CVE-2026-22733</cve>
     </suppress>
 
@@ -74,7 +74,7 @@
     codebase.
     -->
     <suppress>
-        <gav regex="true">^.*org\.springframework:spring-web(mvc)?$</gav>
+        <gav regex="true">^.*org\.springframework:.*$</gav>
         <cve>CVE-2026-22735</cve>
     </suppress>
 
@@ -85,7 +85,7 @@
     rendering or a catch-all /** controller mapping.
     -->
     <suppress>
-        <gav regex="true">^.*org\.springframework:spring-web(mvc)?$</gav>
+        <gav regex="true">^.*org\.springframework:.*$</gav>
         <cve>CVE-2026-22737</cve>
     </suppress>
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -54,4 +54,38 @@
         <gav regex="true">^.*org\.springframework\.security:spring-security-.*$</gav>
         <cve>CVE-2026-22732</cve>
     </suppress>
+
+    <!--
+    Not exploitable in this application. Spring's advisory for CVE-2026-22733 requires a protected
+    application endpoint to be mounted under the Cloud Foundry actuator path, for example
+    /cloudfoundryapplication/**. This application does not expose Cloud Foundry actuator endpoints,
+    only exposes health/info/prometheus under the root actuator base path, and does not mount any
+    application endpoints beneath a Cloud Foundry actuator path.
+    -->
+    <suppress>
+        <gav regex="true">^.*org\.springframework\.boot:spring-boot(-actuator|-actuator-autoconfigure)?$</gav>
+        <cve>CVE-2026-22733</cve>
+    </suppress>
+
+    <!--
+    Not exploitable in this application. Spring's advisory for CVE-2026-22735 requires Server-Sent
+    Events (SSE) usage that streams attacker-controlled plain text to other users. This application
+    does not use SSE: there are no SseEmitter, ServerSentEvent, or text/event-stream handlers in the
+    codebase.
+    -->
+    <suppress>
+        <gav regex="true">^.*org\.springframework:spring-web(mvc)?$</gav>
+        <cve>CVE-2026-22735</cve>
+    </suppress>
+
+    <!--
+    Not exploitable in this application. Spring's advisory for CVE-2026-22737 requires ScriptTemplate
+    views (for example JRuby or Jython) together with a /** mapping that renders an implicit view.
+    This application uses JSP views under /WEB-INF/jsp and does not configure ScriptTemplate view
+    rendering or a catch-all /** controller mapping.
+    -->
+    <suppress>
+        <gav regex="true">^.*org\.springframework:spring-web(mvc)?$</gav>
+        <cve>CVE-2026-22737</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
Support.


### Change description ###
Suppress 3 Spring CVEs that are present in the dependency graph but are not exploitable in this application:
  - CVE-2026-22733: This issue requires a protected application endpoint to be mounted under the Cloud Foundry actuator path, such as /cloudfoundryapplication/**. This app does not expose Cloud Foundry actuator endpoints and only exposes health, info, and prometheus.
  - CVE-2026-22735: This issue requires Server-Sent Events usage with attacker-controlled plain text streamed to other users. This app does not use SSE.
  - CVE-2026-22737: This issue requires Spring ScriptTemplate views plus a catch-all /** mapping with implicit view resolution. This app uses JSP views under /WEB-INF/jsp and does not configure ScriptTemplate rendering or a catch-all controller mapping.




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
