### PR TITLE
SIDM-10377: Update nightly test triggers

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -1,7 +1,7 @@
 #!groovy
 
 properties([
-    pipelineTriggers([cron('TZ=Europe/London\nH 07 * * 1-5')]),
+    pipelineTriggers([cron('TZ=Europe/London\nH(0-30) 08 * * 1-5\nH(15-45) 18 * * 1-5')]),
 
     parameters([
         string(name: 'ENVIRONMENT', defaultValue: 'aat', description: 'Environment to test'),

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -33,15 +33,18 @@
         <cve>CVE-2025-46392</cve>
     </suppress>
 
-    <!-- False positive: CVE applies to Go distribution, not Netflix Java stats jar -->
+    <!-- False positive: CVEs apply to Go distribution, not Netflix Java stats jar -->
     <suppress>
         <notes><![CDATA[
-        False positive: netflix-statistics-0.1.1.jar is a Maven Java artifact. CVE-2026-33540
-        applies to github.com/distribution/distribution (Go), not this package. Suppressed by
-        exact SHA-1 to avoid CPE matcher differences.
+        False positive: netflix-statistics-0.1.1.jar is a Maven Java artifact.
+        CVE-2026-33540, CVE-2026-35172, and CVE-2026-41888 apply to
+        github.com/distribution/distribution (Go), not this package. Suppressed by exact
+        SHA-1 to avoid CPE matcher differences.
         ]]></notes>
         <sha1>12F6E48253F9CAFA0E24D7D232FF504C52143212</sha1>
         <cve>CVE-2026-33540</cve>
+        <cve>CVE-2026-35172</cve>
+        <cve>CVE-2026-41888</cve>
     </suppress>
 
     <!--


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-10377


### Change description ###
Update Jenkinsfile_nightly to run the nightly test pipeline twice per weekday:
* once in the morning using a Jenkins-hashed minute between 08:00 and 08:30
* once in the evening using a Jenkins-hashed minute between 18:15 and 18:45

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
