### PR TITLE
Disable cross-browser nightly tests

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -16,7 +16,7 @@ properties([
         booleanParam(name: 'skipSecurityScanTests', defaultValue: false, description: 'Runs on aat env only, tick the checkbox for skip'),
         booleanParam(name: 'skipMutationTests', defaultValue: false, description: 'Tick the checkbox for skip'),
         booleanParam(name: 'skipFullFunctionalTests', defaultValue: false, description: 'Tick the checkbox for skip'),
-        booleanParam(name: 'skipCrossBrowserTests', defaultValue: false, description: 'Tick the checkbox for skip'),
+        booleanParam(name: 'skipCrossBrowserTests', defaultValue: true, description: 'Tick the checkbox for skip'),
         booleanParam(name: 'skipFortifyTests', defaultValue: false, description: 'Tick the checkbox for skip'),
     ])
 ])


### PR DESCRIPTION
Set skipCrossBrowserTests to true by default for the nightly pipeline so cross-browser tests are skipped while the AAT token failure is investigated.