### PR TITLE
Keep Playwright bump scoped to requested changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,66 +203,29 @@ allprojects {
     description = 'Executes functional tests against a running instance'
   }
 
-  def commandWithProjectNode = { List<String> command ->
-    [
-      'bash',
-      '-lc',
-      '''
-        set -e
-
-        if [ -f .nvmrc ]; then
-          echo "Selecting Node version from .nvmrc: $(cat .nvmrc)"
-
-          if [ -s /opt/nvm/nvm.sh ]; then
-            export NVM_DIR='/home/jenkinsssh/.nvm'
-            . /opt/nvm/nvm.sh || true
-          elif [ -s "$NVM_DIR/nvm.sh" ]; then
-            . "$NVM_DIR/nvm.sh"
-          elif [ -s "$HOME/.nvm/nvm.sh" ]; then
-            export NVM_DIR="$HOME/.nvm"
-            . "$NVM_DIR/nvm.sh"
-          fi
-
-          if command -v nvm >/dev/null 2>&1; then
-            nvm install
-            nvm use
-          else
-            echo "nvm is not available; using node from PATH"
-          fi
-        fi
-
-        echo "Using node $(node --version)"
-        echo "Using yarn $(yarn --version)"
-        exec "$@"
-      '''.stripIndent(),
-      'node-command'
-    ] + command
-  }
-
   task yarnInstall(type: Exec) {
     workingDir '.'
-    environment 'PUPPETEER_SKIP_DOWNLOAD', 'true'
-    commandLine commandWithProjectNode(['yarn', 'install'])
+    commandLine 'yarn', 'install'
   }
 
   task playwrightInstall(type: Exec, dependsOn: ':yarnInstall') {
     workingDir '.'
-    commandLine commandWithProjectNode(['node_modules/.bin/playwright', 'install', 'chromium', 'firefox', 'webkit'])
+    commandLine 'node_modules/.bin/playwright', 'install', 'chromium', 'firefox', 'webkit'
   }
 
   task playwrightInstallChromium(type: Exec, dependsOn: ':yarnInstall') {
     workingDir '.'
-    commandLine commandWithProjectNode(['node_modules/.bin/playwright', 'install', 'chromium'])
+    commandLine 'node_modules/.bin/playwright', 'install', 'chromium'
   }
 
   task notifyClientInstall(type: Exec) {
     workingDir '.'
-    commandLine commandWithProjectNode(['yarn', 'add', 'notifications-node-client'])
+    commandLine 'yarn', 'add', 'notifications-node-client'
   }
 
   task codeceptSmoke(type: Exec, dependsOn: ':playwrightInstallChromium') {
     workingDir '.'
-    commandLine commandWithProjectNode(['node_modules/codeceptjs/bin/codecept.js', 'run', '--grep', '@smoke', '--verbose', '--reporter', 'mocha-multi', '-c', 'codecept.smoke.conf.js'])
+    commandLine 'node_modules/codeceptjs/bin/codecept.js', 'run', '--grep', '@smoke', '--verbose', '--reporter', 'mocha-multi', '-c', 'codecept.smoke.conf.js'
   }
 
   task codeceptSmokeReport(type: Exec) {
@@ -280,12 +243,12 @@ allprojects {
 
       hasAllure && hasResults
     }
-    commandLine commandWithProjectNode(['yarn', 'test-smoke-report'])
+    commandLine 'yarn', 'test-smoke-report'
   }
 
   task codeceptFunctional(type: Exec, dependsOn: ':playwrightInstallChromium') {
     workingDir '.'
-    commandLine commandWithProjectNode(['node_modules/codeceptjs/bin/codecept.js', 'run', '--grep', '@functional', '--verbose', '--reporter', 'mocha-multi'])
+    commandLine 'node_modules/codeceptjs/bin/codecept.js', 'run', '--grep', '@functional', '--verbose', '--reporter', 'mocha-multi'
   }
 
   task codeceptFunctionalReport(type: Exec) {
@@ -303,7 +266,7 @@ allprojects {
 
       hasAllure && hasResults
     }
-    commandLine commandWithProjectNode(['yarn', 'test-functional-report'])
+    commandLine 'yarn', 'test-functional-report'
   }
 
   task crossbrowser(dependsOn: ':codeceptFunctionalCrossBrowser') {
@@ -313,7 +276,7 @@ allprojects {
 
   task codeceptFunctionalCrossBrowser(type: Exec, dependsOn: ':playwrightInstall') {
     workingDir '.'
-    commandLine commandWithProjectNode(['node_modules/codeceptjs/bin/codecept.js', 'run-multiple', '--all', '--config', 'codecept.crossbrowser.conf.js', '--grep', '@crossbrowser', '--verbose', '--debug', '--steps', '--reporter', 'mocha-multi'])
+    commandLine 'node_modules/codeceptjs/bin/codecept.js', 'run-multiple', '--all', '--config', 'codecept.crossbrowser.conf.js', '--grep', '@crossbrowser', '--verbose', '--debug', '--steps', '--reporter', 'mocha-multi'
   }
 
   task codeceptFunctionalCrossBrowserReport(type: Exec) {
@@ -332,7 +295,7 @@ allprojects {
 
       hasAllure && hasResults
     }
-    commandLine commandWithProjectNode(['yarn', 'test-crossbrowser-report'])
+    commandLine 'yarn', 'test-crossbrowser-report'
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -4,11 +4,10 @@
   "repository": "git@github.com:hmcts/idam-web-public.git",
   "license": "MIT",
   "engines": {
-    "node": ">=20 <24 || >=24.18.0"
+    "node": ">=18"
   },
   "devDependencies": {
     "@codeceptjs/allure-legacy": "^1.0.2",
-    "@playwright/test": "1.60.0",
     "allure-commandline": "^2.27.0",
     "chai": "^6.0.0",
     "codeceptjs": "^3.6.4",

--- a/src/test/js/shared/idam_helper.js
+++ b/src/test/js/shared/idam_helper.js
@@ -867,61 +867,38 @@ class IdamHelper extends Helper {
     }
 
     async  getToken() {
-        if (TestData.FUNCTIONAL_TEST_TOKEN && TestData.FUNCTIONAL_TEST_TOKEN.trim() !== "") {
-            return TestData.FUNCTIONAL_TEST_TOKEN;
-        }
+        try {
+            // Check if TestData.TOKEN is not empty or null
 
-        if (!TestData.FUNCTIONAL_TEST_SERVICE_CLIENT_SECRET) {
-            throw new Error('FUNCTIONAL_TEST_SERVICE_CLIENT_SECRET is required to fetch a functional test token');
-        }
-
-        const tokenUrl = `${TestData.IDAM_API}/o/token`;
-        const maxAttempts = 3;
-        let lastError;
-
-        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-            try {
-                const response = await fetch(tokenUrl, {
-                    agent: agent,
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/x-www-form-urlencoded',
-                    },
-                    body: new URLSearchParams({
-                        grant_type: 'client_credentials',
-                        client_id: 'idam-functional-test-service',
-                        client_secret: TestData.FUNCTIONAL_TEST_SERVICE_CLIENT_SECRET,
-                        scope: 'profile roles',
-                    }),
-                });
-
-                if (!response.ok) {
-                    const error = new Error(`Failed to fetch token from ${tokenUrl}; response status ${response.status}`);
-                    error.status = response.status;
-                    throw error;
-                }
-
-                const tokenData = await response.json();
-                if (!tokenData.access_token) {
-                    throw new Error(`Token response from ${tokenUrl} did not include access_token`);
-                }
-
-                TestData.FUNCTIONAL_TEST_TOKEN = tokenData.access_token;
-                return tokenData.access_token;
-            } catch (error) {
-                lastError = error;
-
-                if (attempt >= maxAttempts || (error.status && error.status < 500)) {
-                    console.trace(`Error fetching token from ${tokenUrl}:`, error);
-                    throw error;
-                }
-
-                console.log(`Token fetch attempt ${attempt} failed; retrying. Error: ${error.message}`);
-                await this.sleep(attempt * 1000);
+            if (TestData.FUNCTIONAL_TEST_TOKEN && TestData.FUNCTIONAL_TEST_TOKEN.trim() !== "") {
+                return TestData.FUNCTIONAL_TEST_TOKEN;
             }
-        }
+            console.log("FUNCTIONAL_TEST_SERVICE_CLIENT_SECRET " + TestData.FUNCTIONAL_TEST_SERVICE_CLIENT_SECRET);
 
-        throw lastError;
+            const response = await fetch(`${TestData.IDAM_API}/o/token`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                },
+                body: new URLSearchParams({
+                    grant_type: 'client_credentials',
+                    client_id: 'idam-functional-test-service',
+                    client_secret: TestData.FUNCTIONAL_TEST_SERVICE_CLIENT_SECRET,
+                    scope: 'profile roles',
+                }),
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to fetch token');
+            }
+
+            const tokenData = await response.json();
+            TestData.FUNCTIONAL_TEST_TOKEN = tokenData.access_token;
+            return tokenData.access_token; // Assuming token is in the 'access_token' field
+        } catch (error) {
+            console.trace('Error fetching token:', error);
+            throw error;
+        }
     }
 
     async createServiceUsingTestingSupportService(serviceName, serviceClientSecret, roleNames, token, scope = [], ssoProviders = [],mfaTurnedOn = false,redirectUrl = null) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,13 +546,6 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@playwright/test@1.60.0":
-  version "1.60.0"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.60.0.tgz#e696c31427e8882851235cd556dc2490c3206d97"
-  integrity sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==
-  dependencies:
-    playwright "1.60.0"
-
 "@puppeteer/browsers@2.10.4":
   version "2.10.4"
   resolved "https://registry.yarnpkg.com/@puppeteer/browsers/-/browsers-2.10.4.tgz#9f8923b206f7932a06d32271b14bbea3368b38f2"


### PR DESCRIPTION
## Summary
- preserve .nvmrc with Node 24.18.0 on nightly-dev
- preserve Playwright pinned to 1.60.0
- remove the extra SIDM-P-v2 changes from nightly-dev that were outside the requested scope: Gradle nvm wrapping, package engine changes, @playwright/test, and idam_helper token retry changes

## Validation
- yarn install --frozen-lockfile --ignore-scripts
- git diff --check
- git log --show-signature -1