### PR TITLE
Use HTTPS agent for notify fetch

### DIFF
--- a/src/test/js/shared/idam_helper.js
+++ b/src/test/js/shared/idam_helper.js
@@ -877,6 +877,7 @@ class IdamHelper extends Helper {
 
             const response = await fetch(`${TestData.IDAM_API}/o/token`, {
                 method: 'POST',
+                agent: agent,
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded',
                 },

--- a/src/test/js/shared/idam_helper.js
+++ b/src/test/js/shared/idam_helper.js
@@ -324,6 +324,7 @@ class IdamHelper extends Helper {
 
     async getEmailFromNotifyUsingTestingSupportService(accessToken, emailAddress) {
         return fetch(`${TestData.IDAM_TESTING_SUPPORT_API}/test/idam/notifications/latest/${emailAddress}`, {
+            agent: agent,
             method: 'GET',
             headers: {'Authorization': 'Bearer ' + accessToken}
         }).then(response => {


### PR DESCRIPTION
Adds the shared HTTPS agent to the testing-support notification fetch. This branch also includes the earlier token-fetch agent fix because nightly-dev does not contain it yet.