### PR TITLE
Address Log4j and Spring Framework CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ allprojects {
   ext['netty.version'] = '4.1.135.Final' // CVE-2026-33871, CVE-2026-33870
   ext['jackson.version'] = '2.18.8'
   ext['spring-framework.version'] = '5.3.39'
-  ext['log4j2.version'] = '2.25.4'
+  ext['log4j2.version'] = '2.25.5'
   ext['kotlin.version'] = '2.4.0'
   ext['tomcat.version'] = '9.0.119' // Fixes CVE-2026-53404, CVE-2026-55956, CVE-2026-55955, CVE-2026-55276, CVE-2026-53434, CVE-2026-50229
 

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -268,6 +268,22 @@
     </suppress>
 
     <!--
+    Not exploitable in this application. Spring's advisory for CVE-2026-41839 requires a WebFlux
+    application with a compromised subdomain that can exchange a known session ID for an
+    authenticated user's session. This application is servlet-based Spring MVC with JSP views,
+    spring-boot-starter-web, embedded Tomcat, Zuul, and Redis-backed Spring Session; the checked
+    codebase does not use Spring WebFlux server handlers/configuration, WebSession, WebFilter,
+    ServerWebExchange, RouterFunction, ServerRequest, or spring-boot-starter-webflux. Spring's
+    listed 5.3.x fixed version is enterprise-support-only; public OSS fixes require moving to
+    Spring Framework 6.2+ / Spring Boot 3, which is disproportionate for this JSP Spring Boot 2.7
+    maintenance-mode application.
+    -->
+    <suppress>
+        <gav regex="true">^org\.springframework:spring-(aop|beans|context|context-support|core|expression|jcl|jdbc|oxm|tx|web|webmvc):5\.3\.39$</gav>
+        <cve>CVE-2026-41839</cve>
+    </suppress>
+
+    <!--
     Not exploitable in this application. Spring's advisories for CVE-2026-41849, CVE-2026-41850,
     CVE-2026-41851, and CVE-2026-41852 require accepting and evaluating untrusted or
     user-controlled SpEL expressions; CVE-2026-41851 also requires caching parsed SpEL expressions.


### PR DESCRIPTION
## Jira link
BAU Support

## Changes
- Bump Log4j 2 from 2.25.4 to 2.25.5 for CVE-2026-49844
- Add a narrow Dependency-Check suppression for CVE-2026-41839 scoped to the reported Spring 5.3.39 modules
- Document WebFlux reachability evidence and Spring 5.3.x enterprise-only fixed-version availability

